### PR TITLE
Statistics: Remove foreign key.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,7 @@ Changelog
 6.2.16 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Statistics: Removed foreign key that caused an error.
 
 
 6.2.15 (2021-01-29)

--- a/src/osha/oira/statistics/model.py
+++ b/src/osha/oira/statistics/model.py
@@ -76,7 +76,6 @@ class CompanyStatistics(Base):
     id = schema.Column(types.Integer(), primary_key=True, autoincrement=True)
     session_id = schema.Column(
         types.Integer(),
-        schema.ForeignKey("assessment.id", onupdate="CASCADE", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )


### PR DESCRIPTION
Was causing (psycopg2.IntegrityError) insert or update on table "company" violates foreign key constraint "company_session_id_fkey".

Refs [SCR-848](https://jira.syslab.com/browse/SCR-848)