### PR TITLE
Update tool info on publish/update

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,7 @@ Changelog
 6.2.19 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Statistics: Update tool info in postgresql when workflow state changes.
 
 
 6.2.18 (2021-03-03)

--- a/src/osha/oira/client/model.py
+++ b/src/osha/oira/client/model.py
@@ -40,6 +40,18 @@ class LoginStatistics(model.BaseObject):
     )
 
 
+class SurveyStatistics(model.BaseObject):
+    """Data table to store survey (tool) information."""
+
+    __tablename__ = "statistics_surveys"
+
+    zodb_path = schema.Column(types.String(512), primary_key=True)
+    language = schema.Column(types.String(128), nullable=True)
+    published = schema.Column(types.Boolean(), nullable=True)
+    published_date = schema.Column(types.DateTime, nullable=True)
+    creation_date = schema.Column(types.DateTime, nullable=True)
+
+
 class UsersNotInterestedInCertificateStatusBox(model.BaseObject):
     """"""
 
@@ -101,7 +113,12 @@ class Certificate(model.BaseObject):
 
 _instrumented = False
 if not _instrumented:
-    for cls in [LoginStatistics, Certificate, UsersNotInterestedInCertificateStatusBox]:
+    for cls in [
+        LoginStatistics,
+        SurveyStatistics,
+        Certificate,
+        UsersNotInterestedInCertificateStatusBox,
+    ]:
         instrument_declarative(cls, metadata._decl_registry, metadata)
 
     _instrumented = True

--- a/src/osha/oira/statistics/browser/configure.zcml
+++ b/src/osha/oira/statistics/browser/configure.zcml
@@ -6,8 +6,15 @@
   <browser:page
       name="update-statistics"
       for="plone.app.layout.navigation.interfaces.INavigationRoot"
-      permission="cmf.ManagePortal"
       class=".views.UpdateStatistics"
+      permission="cmf.ManagePortal"
+      />
+
+  <browser:page
+      name="update-tool-info"
+      for="plone.app.layout.navigation.interfaces.INavigationRoot"
+      class=".views.UpdateToolInfo"
+      permission="cmf.ManagePortal"
       />
 
 </configure>

--- a/src/osha/oira/statistics/browser/views.py
+++ b/src/osha/oira/statistics/browser/views.py
@@ -2,7 +2,10 @@
 from euphorie.client.model import Session as EuphorieSession
 from osha.oira.statistics.model import get_postgres_url
 from osha.oira.statistics.utils import UpdateStatisticsDatabases
+from osha.oira.statistics.utils import update_tool_info
 from Products.Five import BrowserView
+from zope import component
+from zope import schema
 
 import logging
 
@@ -21,5 +24,27 @@ class UpdateStatistics(BrowserView):
             return "Could not get postgres connection URL!"
         update_db = UpdateStatisticsDatabases(EuphorieSession, postgres_url)
         update_db()
+        log.info("Done")
+        return "Done"
+
+
+class UpdateToolInfo(BrowserView):
+    def __call__(self):
+        log.info("Writing survey (tool) information to postgresql")
+        surveys = component.getUtility(
+            schema.interfaces.IVocabularyFactory, "osha.oira.toolversions"
+        )(self.context)
+
+        for survey_path in surveys:
+            survey = self.context["sectors"].unrestrictedTraverse(survey_path)
+            if not survey.portal_type == "euphorie.survey":
+                log.info(
+                    "Object is not a survey but inside "
+                    "surveygroup, skipping. %s" % "/".join(survey.getPhysicalPath())
+                )
+                continue
+
+            update_tool_info(survey)
+
         log.info("Done")
         return "Done"

--- a/src/osha/oira/statistics/configure.zcml
+++ b/src/osha/oira/statistics/configure.zcml
@@ -5,5 +5,10 @@
 
   <include package=".browser" />
 
-</configure>
+  <subscriber
+      for="euphorie.content.survey.ISurvey
+           Products.CMFCore.WorkflowCore.ActionSucceededEvent"
+      handler=".utils.handle_tool_workflow"
+      />
 
+</configure>

--- a/src/osha/oira/statistics/model.py
+++ b/src/osha/oira/statistics/model.py
@@ -52,6 +52,17 @@ class AccountStatistics(Base):
     )
 
 
+class SurveyStatistics(Base):
+    """Statistically relevant data concerning a survey (tool)."""
+
+    __tablename__ = "tool"
+
+    zodb_path = schema.Column(types.String(512), primary_key=True)
+    published_date = schema.Column(types.DateTime, nullable=True)
+    years_online = schema.Column(types.Integer(), nullable=True)
+    num_users = schema.Column(types.Integer(), nullable=True)
+
+
 class SurveySessionStatistics(Base):
     """Statistically relevant data concerning a session."""
 

--- a/src/osha/oira/statistics/model.py
+++ b/src/osha/oira/statistics/model.py
@@ -60,6 +60,7 @@ class SurveySessionStatistics(Base):
     id = schema.Column(types.Integer(), primary_key=True, autoincrement=True)
     start_date = schema.Column(types.DateTime, nullable=False, default=functions.now())
     completion_percentage = schema.Column(types.Integer, nullable=True, default=0)
+    path = schema.Column(types.String(512), nullable=False)
     country = schema.Column(types.String(512), nullable=False)
     sector = schema.Column(types.String(512), nullable=False)
     tool = schema.Column(types.String(512), nullable=False)

--- a/src/osha/oira/statistics/model.py
+++ b/src/osha/oira/statistics/model.py
@@ -64,6 +64,7 @@ class SurveySessionStatistics(Base):
     country = schema.Column(types.String(512), nullable=False)
     sector = schema.Column(types.String(512), nullable=False)
     tool = schema.Column(types.String(512), nullable=False)
+    account_id = schema.Column(types.Integer(), nullable=True)
     account_type = schema.Column(
         Enum([u"guest", u"converted", "full"]), default="full", nullable=True
     )

--- a/src/osha/oira/statistics/utils.py
+++ b/src/osha/oira/statistics/utils.py
@@ -71,6 +71,7 @@ class UpdateStatisticsDatabases(object):
                     id=session.id,
                     start_date=session.created,
                     completion_percentage=session.completion_percentage,
+                    path=session.zodb_path,
                     country=session.zodb_path.split("/")[0].encode("utf-8"),
                     sector=session.zodb_path.split("/")[1].encode("utf-8"),
                     tool=session.zodb_path.split("/")[2].encode("utf-8"),

--- a/src/osha/oira/statistics/utils.py
+++ b/src/osha/oira/statistics/utils.py
@@ -75,6 +75,7 @@ class UpdateStatisticsDatabases(object):
                     country=session.zodb_path.split("/")[0].encode("utf-8"),
                     sector=session.zodb_path.split("/")[1].encode("utf-8"),
                     tool=session.zodb_path.split("/")[2].encode("utf-8"),
+                    account_id=account.id,
                     account_type=account.account_type,
                 )
                 for session, account in batch

--- a/src/osha/oira/statistics/utils.py
+++ b/src/osha/oira/statistics/utils.py
@@ -4,13 +4,14 @@ from euphorie.client.model import Account
 from euphorie.client.model import Company
 from euphorie.client.model import Session as EuphorieSession
 from euphorie.client.model import SurveySession
-from osha.oira.client.model import SurveyStatistics
+from osha.oira.client.model import SurveyStatistics as Survey
 from osha.oira.statistics.model import AccountStatistics
 from osha.oira.statistics.model import Base
 from osha.oira.statistics.model import CompanyStatistics
 from osha.oira.statistics.model import create_session
 from osha.oira.statistics.model import STATISTICS_DATABASE_PATTERN
 from osha.oira.statistics.model import SurveySessionStatistics
+from osha.oira.statistics.model import SurveyStatistics
 
 import logging
 import sqlalchemy
@@ -51,11 +52,44 @@ class UpdateStatisticsDatabases(object):
             bind=self.session_statistics.connection(), checkfirst=True
         )
 
+        self.update_tool(country=country)
         self.update_assessment(country=country)
         self.update_account(country=country)
         self.update_company(country=country)
 
         self.session_statistics.commit()
+
+    def update_tool(self, country=None):
+        tools = (
+            self.session_application.query(
+                Survey,
+                sqlalchemy.func.count(
+                    sqlalchemy.func.distinct(SurveySession.account_id)
+                ),
+            )
+            .filter(Survey.zodb_path == SurveySession.zodb_path)
+            .filter(Survey.published)
+            .group_by(Survey.zodb_path)
+            .order_by(Survey.zodb_path)
+        )
+        if country is not None:
+            tools = tools.filter(Survey.zodb_path.startswith(country))
+
+        def tool_rows(offset):
+            batch = tools.limit(self.b_size).offset(offset)
+            rows = [
+                SurveyStatistics(
+                    zodb_path=tool.zodb_path,
+                    published_date=tool.published_date,
+                    years_online=(datetime.now() - tool.published_date).days / 365,
+                    num_users=num_users,
+                )
+                for tool, num_users in batch
+            ]
+            return rows
+
+        log.info("Table: tool")
+        self._process_batch(tool_rows)
 
     def update_assessment(self, country=None):
         sessions = (
@@ -191,7 +225,9 @@ def update_tool_info(survey):
             log.warn("Cannot handle creation date {}".format(creation_date))
             creation_date = None
 
-    zodb_path = "/".join(survey.getPhysicalPath()[-4:])
+    # cut out the part of the ZODB path that's used in postgresql
+    # (country / sector / tool)
+    zodb_path = "/".join(survey.getPhysicalPath()[-4:-1])
     published = survey.aq_parent.published == survey.id
     published_date = None
     if published:
@@ -200,12 +236,10 @@ def update_tool_info(survey):
         elif isinstance(survey.published, tuple):
             published_date = survey.published[2]
 
-    EuphorieSession.query(SurveyStatistics).filter(
-        SurveyStatistics.zodb_path == zodb_path
-    ).delete()
+    EuphorieSession.query(Survey).filter(Survey.zodb_path == zodb_path).delete()
 
     EuphorieSession.add(
-        SurveyStatistics(
+        Survey(
             zodb_path=zodb_path,
             language=survey.Language(),
             published=published,


### PR DESCRIPTION
Makes the publication date (plus some extra info) of a tool available in postgres for use in the statistics.

This is based on @@write-statistics from the old statistics implementation and reuses the same DB table. They should be able to coexist but we'll want to make sure there is no cron job that calls the old view any more and eventually remove the old code.