### PR TITLE
Statistics: Log row numbers

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,7 @@ Changelog
 7.0.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- More logging in statistics updater.
 
 
 7.0.6 (2021-10-13)

--- a/src/osha/oira/statistics/utils.py
+++ b/src/osha/oira/statistics/utils.py
@@ -43,8 +43,23 @@ class UpdateStatisticsDatabases(object):
         self.statistics_url = statistics_url
         self.b_size = b_size
 
+    def log_counts(self):
+        num_tools = self.session_statistics.query(SurveyStatistics).count()
+        num_assessments = self.session_statistics.query(SurveySessionStatistics).count()
+        num_accounts = self.session_statistics.query(AccountStatistics).count()
+        num_questionnaires = self.session_statistics.query(CompanyStatistics).count()
+        log.info(
+            "Tools: %s, Assessments: %s, Accounts: %s, Questionnaires: %s",
+            num_tools,
+            num_assessments,
+            num_accounts,
+            num_questionnaires,
+        )
+
     def update_database(self, country=None):
         log.info("Init & cleanup")
+        self.log_counts()
+
         Base.metadata.drop_all(
             bind=self.session_statistics.connection(), checkfirst=True
         )
@@ -58,6 +73,9 @@ class UpdateStatisticsDatabases(object):
         self.update_company(country=country)
 
         self.session_statistics.commit()
+
+        log.info("New statistics written")
+        self.log_counts()
 
     def update_tool(self, country=None):
         tools = (


### PR DESCRIPTION
…before and after updating the statistics tables.

Output is something like:

```
INFO:osha.oira.statistics.utils:Updating statistics_global
INFO:osha.oira.statistics.utils:Init & cleanup
INFO:osha.oira.statistics.utils:Tools: 56, Assessments: 739, Accounts: 176, Questionnaires: 279
INFO:osha.oira.statistics.utils:Table: tool
INFO:osha.oira.statistics.utils:Table: assessment
INFO:osha.oira.statistics.utils:Table: account
INFO:osha.oira.statistics.utils:Table: company
INFO:osha.oira.statistics.utils:New statistics written
INFO:osha.oira.statistics.utils:Tools: 56, Assessments: 739, Accounts: 176, Questionnaires: 279
INFO:osha.oira.statistics.utils:Updated statistics_global
```

Refs [SCR-1530](https://jira.syslab.com/browse/SCR-1530)