### PR TITLE
Tweak the session dashboard to not show the organisation tab

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,8 @@ Changelog
 8.2.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Tweak the session dashboard to not show the organisation tab
+  [ale-rt]
 
 
 8.2.2 (2022-09-27)

--- a/src/osha/oira/client/browser/webhelpers.py
+++ b/src/osha/oira/client/browser/webhelpers.py
@@ -12,6 +12,7 @@ log = getLogger(__name__)
 
 class OSHAWebHelpers(WebHelpers):
 
+    hide_organisation_tab = True
     show_completion_percentage = True
 
     @memoize


### PR DESCRIPTION
This depends on https://github.com/euphorie/Euphorie/pull/455, but it does not cause issues with the existing code base.