### PR TITLE
Fix updating tool statistics

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,8 @@ Changelog
 8.2.5 (unreleased)
 ------------------
 
+- Statistics: Fix updating tool statistics.
+  [reinhardt]
 - Statistics: Exclude accounts with certain domains
   (`#923 <https://github.com/syslabcom/scrum/issues/923>`_).
   [reinhardt]

--- a/src/osha/oira/statistics/utils.py
+++ b/src/osha/oira/statistics/utils.py
@@ -106,16 +106,6 @@ class UpdateStatisticsDatabases:
 
     def update_tool(self, country=None):
         log.info("Table: tool")
-        since = (
-            self.session_statistics.query(
-                sqlalchemy.func.max(SurveyStatistics.published_date)
-            ).first()[0]
-            or datetime.min
-        )
-        if self.since and self.since < since:
-            since = self.since
-        if since > datetime.min:
-            log.info("Skipping tools up to and including %s", since)
 
         tools = (
             self.session_application.query(
@@ -125,7 +115,6 @@ class UpdateStatisticsDatabases:
                 ),
                 sqlalchemy.func.count(SurveySession.id),
             )
-            .filter(Survey.published_date > since)
             .filter(Survey.zodb_path == SurveySession.zodb_path)
             .filter(Survey.published)
             .filter(Account.id == SurveySession.account_id)


### PR DESCRIPTION
Statistics: Don't skip tool statistics based on published_date

We need to update at least number of users and assessments regardless of publishing date. It makes sense to skip accounts based on creation date and assessments based on modified date, but this is wrong.

syslabcom/scrum#923