### PR TITLE
Newsletter: Add unsubscribe view

### DIFF
--- a/src/osha/oira/client/browser/configure.zcml
+++ b/src/osha/oira/client/browser/configure.zcml
@@ -162,7 +162,7 @@
   <browser:page
       name="preferences"
       for="euphorie.client.client.IClient"
-      class=".settings.OSHAPreferencesRedirect"
+      class=".client.OSHAClientRedirect"
       permission="zope.Public"
       />
 
@@ -180,6 +180,21 @@
       class=".client.GroupToAddresses"
       permission="zope2.View"
       layer="plonetheme.nuplone.skin.interfaces.NuPloneSkin"
+      />
+
+  <browser:page
+      name="unsubscribe"
+      for="euphorie.client.client.IClient"
+      class=".client.OSHAClientRedirect"
+      permission="zope.Public"
+      />
+
+  <browser:page
+      name="unsubscribe"
+      for="euphorie.client.country.IClientCountry"
+      class=".client.NewsletterUnsubscribe"
+      permission="zope.Public"
+      layer="osha.oira.client.interfaces.IOSHAClientSkinLayer"
       />
 
   <configure package="euphorie.client.browser">

--- a/src/osha/oira/client/browser/settings.py
+++ b/src/osha/oira/client/browser/settings.py
@@ -4,21 +4,9 @@ from osha.oira import _
 from osha.oira.client.model import NewsletterSubscription
 from plone import api
 from plone.memoize.view import memoize
-from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from z3c.form import button
 from z3c.saconfig import Session
-
-
-class OSHAPreferencesRedirect(BrowserView):
-    def __call__(self):
-        country = (
-            api.portal.get_registry_record("euphorie.default_country", default="")
-            or "eu"
-        )
-        return self.request.response.redirect(
-            f"{self.context.absolute_url()}/{country}/@@preferences"
-        )
 
 
 class OSHAPreferences(Preferences):

--- a/src/osha/oira/client/browser/templates/unsubscribe.pt
+++ b/src/osha/oira/client/browser/templates/unsubscribe.pt
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      metal:use-macro="context/@@shell/macros/shell"
+      i18n:domain="euphorie"
+>
+  <body>
+    <metal:content fill-slot="content">
+      <div class="pat-scroll-box scroll-position-top"
+           id="content-pane"
+      >
+        <article>
+          <p tal:condition="not:view/success"
+             i18n:translate="unsubscribe_invalid"
+          >
+            This link is invalid or has expired.
+          </p>
+
+          <tal:success tal:define="
+                         group request/group|nothing;
+                       "
+                       tal:condition="view/success"
+          >
+            <p tal:condition="group"
+               i18n:translate="unsubscribe_success"
+            >
+            You have been unsubscribed from the
+              <strong i18n:name="group">${view/group_title}</strong>
+            newsletter.
+            </p>
+            <p tal:condition="not:group"
+               i18n:translate="unsubscribe_all_success"
+            >
+            You have been unsubscribed from all newsletters.
+            </p>
+          </tal:success>
+
+          <p i18n:translate="link_preferences">
+            Manage your newsletter subsriptions on your
+            <a href="${here/absolute_url}/@@preferences"
+               i18n:name="target"
+               i18n:translate=""
+            >personal preferences page</a>.
+          </p>
+        </article>
+
+      </div>
+    </metal:content>
+  </body>
+</html>


### PR DESCRIPTION
Known issue: The unsubscribe view operates on the default country. If a user from another country clicks the home link, they will not see the assessments of their country, and there is no way to navigate to their country except modify the URL.

syslabcom/scrum#928