### PR TITLE
Statistics update: Monitoring improvements

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,9 @@ Changelog
 9.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Statistics: Improved monitoring
+  (`#1822 <https://github.com/syslabcom/scrum/issues/1822>`_)
+  [reinhardt]
 
 
 9.0.4 (2023-12-12)

--- a/src/osha/oira/statistics/scripts.py
+++ b/src/osha/oira/statistics/scripts.py
@@ -77,4 +77,6 @@ def update_statistics():
         b_size=args.batch_size,
         optimize_cp_query=args.optimize_cp_query,
     )
-    update_db()
+    output = update_db()
+    if "OK" not in output:
+        sys.exit(1)

--- a/src/osha/oira/upgrade/v1/20231220133923_initialize_statistics_for_hungary_and_netherlands/upgrade.py
+++ b/src/osha/oira/upgrade/v1/20231220133923_initialize_statistics_for_hungary_and_netherlands/upgrade.py
@@ -1,0 +1,17 @@
+from ftw.upgrade import UpgradeStep
+from osha.oira.statistics.model import Base
+from osha.oira.statistics.model import create_session
+from osha.oira.statistics.model import get_postgres_url
+from osha.oira.statistics.model import STATISTICS_DATABASE_PATTERN
+
+
+class InitializeStatisticsForHungaryAndNetherlands(UpgradeStep):
+    """Initialize statistics for Germany, Hungary and Netherlands."""
+
+    def __call__(self):
+        for country in ["de", "hu", "nl"]:
+            database = STATISTICS_DATABASE_PATTERN.format(suffix=country)
+            session_statistics = create_session(
+                get_postgres_url().format(database=database)
+            )
+            Base.metadata.create_all(session_statistics.bind, checkfirst=True)


### PR DESCRIPTION
Expose errors so that monitoring can pick them up.
Initialize missing country databases so that they don't throw errors.

syslabcom/scrum#1822