### PR TITLE
Don't limit the number of results of mailing-lists.json

### DIFF
--- a/src/osha/oira/client/browser/client.py
+++ b/src/osha/oira/client/browser/client.py
@@ -106,7 +106,6 @@ class MailingListsJson(BaseJson):
         tools = api.content.find(
             path=brain.getPath(),
             portal_type="euphorie.survey",
-            review_state="published",
         )
         # No filter for non-obsolete -
         # if we get unexpected languages we can try adding that

--- a/src/osha/oira/client/browser/client.py
+++ b/src/osha/oira/client/browser/client.py
@@ -195,11 +195,7 @@ class MailingListsJson(BaseJson):
 
             filtered_brains = filter(filter_items, brains)
 
-            cnt = len(results)
             for brain in filtered_brains:
-                if cnt > 10:
-                    break
-                cnt += 1
                 results.extend(self._get_mailing_lists_for(brain))
 
         return results

--- a/src/osha/oira/client/tests/test_mailing_lists.py
+++ b/src/osha/oira/client/tests/test_mailing_lists.py
@@ -22,11 +22,10 @@ class TestMailingLists(EuphorieIntegrationTestCase):
                         <language>fr</language>
                         </survey>
                     </sector>"""
+
         with api.env.adopt_user("admin"):
             addSurvey(self.portal, BASIC_SURVEY)
             addSurvey(self.portal, survey)
-        self.portal.client.nl.ict["software-development"].reindexObject()
-        self.portal.client.nl.test["second-survey"].reindexObject()
 
     def test_mailing_lists(self):
         request = self.request.clone()


### PR DESCRIPTION
(Rebased onto #230 )

This removes the limit to ten items from the mailing lists json view. This is for use in combination with https://github.com/quaive/quaive.osha/pull/74 which turns off ajax in the autosuggest and thus reduces the number of requests. Therefore it should be viable to return all items in one request.

If it turns out that it isn't viable after all we can consider the batching implementation instead, see #227 .

syslabcom/scrum#1898