### PR TITLE
RecipientLanguageMapping: bail out on empty recipients

### DIFF
--- a/src/osha/oira/client/browser/client.py
+++ b/src/osha/oira/client/browser/client.py
@@ -326,6 +326,8 @@ class RecipientLanguageMapping(BrowserView):
     def results(self):
         recipients = self.request.get("recipients", "[]")
         recipients = loads(recipients)
+        if not recipients:
+            return {}
         query = (
             Session.query(Account.loginname, SurveySession.zodb_path)
             .join(SurveySession, Account.id == SurveySession.account_id)


### PR DESCRIPTION
This avoids a SQL error.

syslabcom/scrum#1621