### PR TITLE
Explicitly load the zcml of plone.restapi.

### DIFF
--- a/src/osha/oira/configure.zcml
+++ b/src/osha/oira/configure.zcml
@@ -28,6 +28,7 @@
 
   <include package="pas.plugins.ldap" />
   <include package="euphorie.deployment" />
+  <include package="plone.restapi" />
   <include package=".client" />
   <include package=".content" />
   <include package=".tiles" />


### PR DESCRIPTION
Otherwise you get an error in the tests:

```
KeyError: 'Profile "profile-osha.oira:default" requires the dependency-profile "profile-plone.restapi:default", which does not exist.'
```