### PR TITLE
Support Plone 6

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,8 +1,13 @@
 Changelog
 =========
 
-9.1.3 (unreleased)
-------------------
+10.0.0 (unreleased)
+-------------------
+
+- Get rid of the htmllaundry dependency, replace it with the
+  equivalent code from Euphorie.
+  Declare support for Plone 6.
+  [ale-rt]
 
 - Show company certificates in overview
   (`#2142 <https://github.com/syslabcom/scrum/issues/2142>`_)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import monkeypatch_setup  # noqa: F401
 import os
 
 
-version = "9.1.3.dev0"
+version = "10.0.0.dev0"
 
 setup(
     name="osha.oira",
@@ -18,7 +18,8 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "Framework :: Plone",
-        "Framework :: Plone :: 5.1",
+        "Framework :: Plone :: 5.2",
+        "Framework :: Plone :: 6.0",
         "License :: OSI Approved :: GNU General Public License (GPL)",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.8",
@@ -38,7 +39,6 @@ setup(
     install_requires=[
         "Euphorie >=14.0.0",
         "ftw.upgrade",
-        "htmllaundry",
         "mobile.sniffer",
         "NuPlone >=2.1.0",
         "pas.plugins.ldap",

--- a/src/osha/oira/content/country.py
+++ b/src/osha/oira/content/country.py
@@ -1,5 +1,4 @@
 from euphorie.content import MessageFactory as _
-from htmllaundry.z3cform import HtmlText
 from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.supermodel import model
@@ -8,6 +7,15 @@ from zope import schema
 from zope.interface import alsoProvides
 from zope.interface import Invalid
 from zope.interface import invariant
+
+try:
+    # This needs a merge of https://github.com/euphorie/Euphorie/pull/739
+    from euphorie.htmllaundry.z3cform import HtmlText
+except ImportError:
+    # BBB This may not work with lxml 5.2+ (Plone 6.0.11+).
+    # On those versions it needs a merge and release of this PR:
+    # https://github.com/syslabcom/htmllaundry/pull/2
+    from htmllaundry.z3cform import HtmlText
 
 
 class IOSHACountry(model.Schema):


### PR DESCRIPTION
Get rid of the htmllaundry dependency, replace it with the equivalent code from Euphorie. Declare support for Plone 6.