### PR TITLE
Check if we can run the tests without fiddling with the request layers

### DIFF
--- a/src/osha/oira/content/tests/test_risk.py
+++ b/src/osha/oira/content/tests/test_risk.py
@@ -22,6 +22,27 @@ class OiRARiskTests(OiRAIntegrationTestCase):
         survey = self._create(surveygroup, "euphorie.survey", "survey")
         return self._create(survey, "euphorie.module", "module")
 
+    def test_request_layers(self):
+        """Test that request layers are set up correctly."""
+        from osha.oira.interfaces import IOSHAContentSkinLayer
+        from zope.interface import noLongerProvides
+
+        # Given we have the IOSHAContentSkinLayer we get the AddView defined in
+        # out custom package
+        self.assertTrue(IOSHAContentSkinLayer.providedBy(self.request))
+        self.assertEqual(
+            repr(self.portal.restrictedTraverse("++add++euphorie.risk").__class__),
+            "<class 'osha.oira.content.browser.risk.AddView'>",
+        )
+
+        # If we remove the IOSHAContentSkinLayer we get the AddView
+        # that comes from euphorie
+        noLongerProvides(self.request, IOSHAContentSkinLayer)
+        self.assertEqual(
+            repr(self.portal.restrictedTraverse("++add++euphorie.risk").__class__),
+            "<class 'euphorie.content.browser.risk.AddView'>",
+        )
+
     def testDynamicDescription(self):
         """#3343: Customize infoBubble description according to calculation
         method.

--- a/src/osha/oira/content/tests/test_risk.py
+++ b/src/osha/oira/content/tests/test_risk.py
@@ -1,9 +1,7 @@
-from osha.oira import interfaces
 from osha.oira.testing import OiRAIntegrationTestCase
 from plonetheme.nuplone.z3cform.widget import SingleRadioWidget
 from z3c.form.browser.select import SelectWidget
 from z3c.form.interfaces import IFieldWidget
-from zope.interface import alsoProvides
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 
@@ -31,10 +29,6 @@ class OiRARiskTests(OiRAIntegrationTestCase):
         self.loginAsPortalOwner()
         for risk_type in ["kinney", "french"]:
             module = self.createModule(risk_type, "sector-" + risk_type)
-            # Merely installing the OiRA skin doesn't set it's layer on the
-            # request. This happens during IBeforeTraverseEvent, so we have to do
-            # here manually
-            alsoProvides(self.portal.REQUEST, interfaces.IOSHAContentSkinLayer)
 
             # Test AddForm
             form = module.unrestrictedTraverse("++add++euphorie.risk").form_instance
@@ -58,7 +52,6 @@ class OiRARiskTests(OiRAIntegrationTestCase):
         """#1537 The Choice fields must be uniform and all radio buttons."""
         self.loginAsPortalOwner()
         module = self.createModule()
-        alsoProvides(self.portal.REQUEST, interfaces.IOSHAContentSkinLayer)
         form = module.unrestrictedTraverse("++add++euphorie.risk").form_instance
         form.updateFields()
 

--- a/src/osha/oira/interfaces.py
+++ b/src/osha/oira/interfaces.py
@@ -1,5 +1,5 @@
+from euphorie.content.interfaces import IEuphorieContentLayer
 from osha.oira.nuplone.interfaces import IOiRAFormLayer
-from plonetheme.nuplone.skin.interfaces import NuPloneSkin
 from zope.interface import Interface
 
 
@@ -8,5 +8,5 @@ class IProductLayer(Interface):
     installed."""
 
 
-class IOSHAContentSkinLayer(IOiRAFormLayer, NuPloneSkin):
+class IOSHAContentSkinLayer(IOiRAFormLayer, IEuphorieContentLayer):
     """Marker interface for the CMS/Content editing skin."""

--- a/src/osha/oira/profiles/default/metadata.xml
+++ b/src/osha/oira/profiles/default/metadata.xml
@@ -4,6 +4,7 @@
     ftw.upgrade in the package osha.oira.upgrade
   -->
   <dependencies>
+    <dependency>profile-euphorie.deployment:default</dependency>
     <dependency>profile-pas.plugins.ldap:default</dependency>
     <dependency>profile-plone.restapi:default</dependency>
     <dependency>profile-ftw.upgrade:default</dependency>


### PR DESCRIPTION
The answer is yes, they do:

```shell
ale@avo:~/Code/plone/tests/osha-oira$ ./bin/test -t OiRARiskTests                                                                                                                                                                                                                                                                                                                            
...
  Ran 2 tests with 0 failures, 0 errors, 0 skipped in 10.657 seconds.
Tearing down left over layers:
  Tear down osha.oira.testing.osha.oira:Integration in 0.000 seconds.
  Tear down osha.oira.testing.OiRAFixture in 0.002 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.017 seconds.
  Tear down plone.testing.zope.Startup in 0.002 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.001 seconds.
```