### PR TITLE
Map images is now a browser view

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,10 @@ Changelog
 - Remove an unused behavior.
   [ale-rt]
 
+- Add a "map-images" view to add images to the surveys.
+  The view used to be a script in the old oira buildout.
+  [ale-rt]
+
 - Show company certificates in overview
   (`#2142 <https://github.com/syslabcom/scrum/issues/2142>`_)
   [reinhardt]

--- a/src/osha/oira/content/browser/configure.zcml
+++ b/src/osha/oira/content/browser/configure.zcml
@@ -240,4 +240,11 @@
       template="templates/about.pt"
       />
 
+  <browser:page
+      name="map-images"
+      for="plone.app.layout.navigation.interfaces.INavigationRoot"
+      class=".map_images.MapImages"
+      permission="cmf.ManagePortal"
+      />
+
 </configure>

--- a/src/osha/oira/content/browser/map_images.py
+++ b/src/osha/oira/content/browser/map_images.py
@@ -1,0 +1,111 @@
+import logging
+import sys
+import urllib.request
+from pathlib import posixpath
+from urllib.parse import unquote, urlparse
+
+import requests
+import transaction
+from lxml import etree
+from plone.namedfile.file import NamedBlobImage
+from zope.component.hooks import setSite
+
+log = logging.getLogger(__name__)
+
+BASE_URL = "https://oiraproject.eu"
+
+
+if len(sys.argv) > 3:
+    images_path = posixpath.abspath(sys.argv[3])
+else:
+    images_path = posixpath.abspath(".")
+
+app = locals()["app"]
+setSite(app["Plone2"])
+wt = app["Plone2"]["portal_workflow"]
+
+
+def get_filename():
+    sourcename = urlparse(img.attrib["src"]).path.split("/")[-1]
+    basename = unquote(sourcename.split(".")[0]).strip()
+    if " " in basename:
+        name = " ".join([part for part in basename.split(" ")[:-1]])
+    else:
+        name = basename
+    filename = "{} 300.png".format(name)
+    return filename
+
+
+for page_num in range(255):
+    url = "{}/en/oira-tools?search_api_fulltext=&sort_by=title" "&page={}".format(
+        BASE_URL, page_num
+    )
+    page = requests.get(url).text
+    tree = etree.HTML(page)
+    tool_elements = tree.findall(".//div[@class='views-field views-field-nothing']")
+    if not tool_elements:
+        log.warning("Stopping at page {} (no more tools found)".format(page_num))
+        break
+    for elem in tool_elements:
+        link = elem.find(".//div[@class='tool-link']/a")
+        if link is not None:
+            path = "/".join(
+                urlparse(unquote(link.attrib["href"]))
+                .path.strip()
+                .rstrip("/")
+                .split("/")[-3:]
+            )
+        else:
+            continue
+
+        try:
+            surveygroup = app.unrestrictedTraverse("/".join(("/Plone2/sectors", path)))
+        except KeyError:
+            log.warning("Tool not found: {}".format(path))
+            continue
+        if all(getattr(survey, "image", None) for survey in surveygroup.values()):
+            log.warning("Already has image: {}".format(path))
+            continue
+
+        img = elem.find(".//div[@class='views-field views-field-field-image']//img")
+        if img is None:
+            log.warning("No image for {}".format(path))
+            continue
+        filename = get_filename()
+        filepath = posixpath.join(images_path, filename)
+        blob_image = None
+        if not posixpath.exists(filepath):
+            log.warning(
+                "{}: Image file not found: {} ({}). Attempting download".format(
+                    path, filepath, img.attrib["src"]
+                )
+            )
+            try:
+                urllib.request.urlretrieve(
+                    "{}{}".format(BASE_URL, img.attrib["src"]), filepath
+                )
+            except Exception as e:
+                log.warning(
+                    "Unable to download image from website. Error: {}".format(e)
+                )
+                continue
+        try:
+            with open(filepath, "rb") as imagefile:
+                blob_image = NamedBlobImage(data=imagefile.read(), filename=filename)
+        except Exception as e:
+            log.warning("Unable to open image. Error: {}".format(e))
+            continue
+
+        if not blob_image:
+            continue
+        for survey in surveygroup.values():
+            setattr(survey, "image", blob_image)
+
+            if getattr(surveygroup, "published", None) == survey.getId():
+                try:
+                    wt.doActionFor(survey, "update")
+                except Exception as e:
+                    log.exception(e)
+                    continue
+
+transaction.commit()

--- a/src/osha/oira/content/browser/map_images.py
+++ b/src/osha/oira/content/browser/map_images.py
@@ -8,104 +8,113 @@ import requests
 import transaction
 from lxml import etree
 from plone.namedfile.file import NamedBlobImage
+from Products.Five import BrowserView
 from zope.component.hooks import setSite
 
-log = logging.getLogger(__name__)
 
-BASE_URL = "https://oiraproject.eu"
+class MapImages(BrowserView):
+    """ This used to be a buildout script, see:
 
+    https://github.com/EU-OSHA/oira.application.buildout/blob/f75c33a3db968bcb1b2ffa68b3ca4a66b396a6d4/scripts/map_images.py
+    """  # noqa: E501
 
-if len(sys.argv) > 3:
-    images_path = posixpath.abspath(sys.argv[3])
-else:
-    images_path = posixpath.abspath(".")
+    def __call__(self):
+        log = logging.getLogger(__name__)
 
-app = locals()["app"]
-setSite(app["Plone2"])
-wt = app["Plone2"]["portal_workflow"]
+        BASE_URL = "https://oiraproject.eu"
 
 
-def get_filename():
-    sourcename = urlparse(img.attrib["src"]).path.split("/")[-1]
-    basename = unquote(sourcename.split(".")[0]).strip()
-    if " " in basename:
-        name = " ".join([part for part in basename.split(" ")[:-1]])
-    else:
-        name = basename
-    filename = "{} 300.png".format(name)
-    return filename
-
-
-for page_num in range(255):
-    url = "{}/en/oira-tools?search_api_fulltext=&sort_by=title" "&page={}".format(
-        BASE_URL, page_num
-    )
-    page = requests.get(url).text
-    tree = etree.HTML(page)
-    tool_elements = tree.findall(".//div[@class='views-field views-field-nothing']")
-    if not tool_elements:
-        log.warning("Stopping at page {} (no more tools found)".format(page_num))
-        break
-    for elem in tool_elements:
-        link = elem.find(".//div[@class='tool-link']/a")
-        if link is not None:
-            path = "/".join(
-                urlparse(unquote(link.attrib["href"]))
-                .path.strip()
-                .rstrip("/")
-                .split("/")[-3:]
-            )
+        if len(sys.argv) > 3:
+            images_path = posixpath.abspath(sys.argv[3])
         else:
-            continue
+            images_path = posixpath.abspath(".")
 
-        try:
-            surveygroup = app.unrestrictedTraverse("/".join(("/Plone2/sectors", path)))
-        except KeyError:
-            log.warning("Tool not found: {}".format(path))
-            continue
-        if all(getattr(survey, "image", None) for survey in surveygroup.values()):
-            log.warning("Already has image: {}".format(path))
-            continue
+        app = locals()["app"]
+        setSite(app["Plone2"])
+        wt = app["Plone2"]["portal_workflow"]
 
-        img = elem.find(".//div[@class='views-field views-field-field-image']//img")
-        if img is None:
-            log.warning("No image for {}".format(path))
-            continue
-        filename = get_filename()
-        filepath = posixpath.join(images_path, filename)
-        blob_image = None
-        if not posixpath.exists(filepath):
-            log.warning(
-                "{}: Image file not found: {} ({}). Attempting download".format(
-                    path, filepath, img.attrib["src"]
-                )
+
+        def get_filename():
+            sourcename = urlparse(img.attrib["src"]).path.split("/")[-1]
+            basename = unquote(sourcename.split(".")[0]).strip()
+            if " " in basename:
+                name = " ".join([part for part in basename.split(" ")[:-1]])
+            else:
+                name = basename
+            filename = "{} 300.png".format(name)
+            return filename
+
+
+        for page_num in range(255):
+            url = "{}/en/oira-tools?search_api_fulltext=&sort_by=title" "&page={}".format(
+                BASE_URL, page_num
             )
-            try:
-                urllib.request.urlretrieve(
-                    "{}{}".format(BASE_URL, img.attrib["src"]), filepath
-                )
-            except Exception as e:
-                log.warning(
-                    "Unable to download image from website. Error: {}".format(e)
-                )
-                continue
-        try:
-            with open(filepath, "rb") as imagefile:
-                blob_image = NamedBlobImage(data=imagefile.read(), filename=filename)
-        except Exception as e:
-            log.warning("Unable to open image. Error: {}".format(e))
-            continue
-
-        if not blob_image:
-            continue
-        for survey in surveygroup.values():
-            setattr(survey, "image", blob_image)
-
-            if getattr(surveygroup, "published", None) == survey.getId():
-                try:
-                    wt.doActionFor(survey, "update")
-                except Exception as e:
-                    log.exception(e)
+            page = requests.get(url).text
+            tree = etree.HTML(page)
+            tool_elements = tree.findall(".//div[@class='views-field views-field-nothing']")
+            if not tool_elements:
+                log.warning("Stopping at page {} (no more tools found)".format(page_num))
+                break
+            for elem in tool_elements:
+                link = elem.find(".//div[@class='tool-link']/a")
+                if link is not None:
+                    path = "/".join(
+                        urlparse(unquote(link.attrib["href"]))
+                        .path.strip()
+                        .rstrip("/")
+                        .split("/")[-3:]
+                    )
+                else:
                     continue
 
-transaction.commit()
+                try:
+                    surveygroup = app.unrestrictedTraverse("/".join(("/Plone2/sectors", path)))
+                except KeyError:
+                    log.warning("Tool not found: {}".format(path))
+                    continue
+                if all(getattr(survey, "image", None) for survey in surveygroup.values()):
+                    log.warning("Already has image: {}".format(path))
+                    continue
+
+                img = elem.find(".//div[@class='views-field views-field-field-image']//img")
+                if img is None:
+                    log.warning("No image for {}".format(path))
+                    continue
+                filename = get_filename()
+                filepath = posixpath.join(images_path, filename)
+                blob_image = None
+                if not posixpath.exists(filepath):
+                    log.warning(
+                        "{}: Image file not found: {} ({}). Attempting download".format(
+                            path, filepath, img.attrib["src"]
+                        )
+                    )
+                    try:
+                        urllib.request.urlretrieve(
+                            "{}{}".format(BASE_URL, img.attrib["src"]), filepath
+                        )
+                    except Exception as e:
+                        log.warning(
+                            "Unable to download image from website. Error: {}".format(e)
+                        )
+                        continue
+                try:
+                    with open(filepath, "rb") as imagefile:
+                        blob_image = NamedBlobImage(data=imagefile.read(), filename=filename)
+                except Exception as e:
+                    log.warning("Unable to open image. Error: {}".format(e))
+                    continue
+
+                if not blob_image:
+                    continue
+                for survey in surveygroup.values():
+                    setattr(survey, "image", blob_image)
+
+                    if getattr(surveygroup, "published", None) == survey.getId():
+                        try:
+                            wt.doActionFor(survey, "update")
+                        except Exception as e:
+                            log.exception(e)
+                            continue
+
+        transaction.commit()

--- a/src/osha/oira/content/browser/map_images.py
+++ b/src/osha/oira/content/browser/map_images.py
@@ -1,10 +1,10 @@
 from lxml import etree
 from pathlib import posixpath
+from plone import api
 from plone.namedfile.file import NamedBlobImage
 from Products.Five import BrowserView
 from urllib.parse import unquote
 from urllib.parse import urlparse
-from zope.component.hooks import setSite
 
 import logging
 import requests
@@ -28,9 +28,9 @@ class MapImages(BrowserView):
         else:
             images_path = posixpath.abspath(".")
 
-        app = locals()["app"]
-        setSite(app["Plone2"])
-        wt = app["Plone2"]["portal_workflow"]
+        portal = api.portal.get()
+        sectors = portal.sectors
+        wt = api.portal.get_tool("portal_workflow")
 
         def get_filename():
             sourcename = urlparse(img.attrib["src"]).path.split("/")[-1]
@@ -68,9 +68,7 @@ class MapImages(BrowserView):
                     continue
 
                 try:
-                    surveygroup = app.unrestrictedTraverse(
-                        "/".join(("/Plone2/sectors", path))
-                    )
+                    surveygroup = sectors.unrestrictedTraverse(path)
                 except KeyError:
                     log.warning(f"Tool not found: {path}")
                     continue

--- a/src/osha/oira/content/browser/map_images.py
+++ b/src/osha/oira/content/browser/map_images.py
@@ -9,7 +9,6 @@ from zope.component.hooks import setSite
 import logging
 import requests
 import sys
-import transaction
 import urllib.request
 
 
@@ -126,5 +125,3 @@ class MapImages(BrowserView):
                         except Exception as e:
                             log.exception(e)
                             continue
-
-        transaction.commit()

--- a/src/osha/oira/content/browser/map_images.py
+++ b/src/osha/oira/content/browser/map_images.py
@@ -123,3 +123,4 @@ class MapImages(BrowserView):
                         except Exception as e:
                             log.exception(e)
                             continue
+        return "OK"

--- a/src/osha/oira/content/browser/map_images.py
+++ b/src/osha/oira/content/browser/map_images.py
@@ -21,7 +21,8 @@ class MapImages(BrowserView):
     def __call__(self):
         log = logging.getLogger(__name__)
 
-        BASE_URL = "https://oiraproject.eu"
+        log.info("Updating tool images")
+        BASE_URL = "https://oira.osha.europa.eu"
 
         if len(sys.argv) > 3:
             images_path = posixpath.abspath(sys.argv[3])
@@ -45,8 +46,9 @@ class MapImages(BrowserView):
         for page_num in range(255):
             url = (
                 "{}/en/oira-tools?search_api_fulltext=&sort_by=title"
-                "&page={}".format(BASE_URL, page_num)
+                "&page=%2C{}".format(BASE_URL, page_num)
             )
+            log.info("Scanning %s", url)
             page = requests.get(url).text
             tree = etree.HTML(page)
             tool_elements = tree.findall(
@@ -56,7 +58,7 @@ class MapImages(BrowserView):
                 log.warning(f"Stopping at page {page_num} (no more tools found)")
                 break
             for elem in tool_elements:
-                link = elem.find(".//div[@class='tool-link']/a")
+                link = elem.find('.//div[@class="button-risk"]/a')
                 if link is not None:
                     path = "/".join(
                         urlparse(unquote(link.attrib["href"]))
@@ -78,9 +80,7 @@ class MapImages(BrowserView):
                     log.warning(f"Already has image: {path}")
                     continue
 
-                img = elem.find(
-                    ".//div[@class='views-field views-field-field-image']//img"
-                )
+                img = elem.find(".//div[@class='content-view-oira-tools-view']/img")
                 if img is None:
                     log.warning(f"No image for {path}")
                     continue


### PR DESCRIPTION
I copied the code from https://github.com/EU-OSHA/oira.application.buildout/blob/f75c33a3db968bcb1b2ffa68b3ca4a66b396a6d4/scripts/map_images.py and adapted it to work in the context of a view.

The reason is that we want to get rid of that custom buildout, so the code has to be moved.