### PR TITLE
Add REST API service @tool-versions.

### DIFF
--- a/src/osha/oira/configure.zcml
+++ b/src/osha/oira/configure.zcml
@@ -36,6 +36,7 @@
   <include package=".ploneintranet" />
   <include package=".upgrade" />
   <include package=".statistics" />
+  <include package=".services" />
 
   <!-- Vocabularies -->
   <utility

--- a/src/osha/oira/services/configure.zcml
+++ b/src/osha/oira/services/configure.zcml
@@ -1,0 +1,15 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    >
+
+  <plone:service
+      method="GET"
+      factory=".surveys.ToolVersionsGet"
+      for="plone.dexterity.interfaces.IDexterityContainer"
+      permission="zope2.View"
+      layer="osha.oira.interfaces.IOSHAContentSkinLayer"
+      name="@tool-versions"
+      />
+
+</configure>

--- a/src/osha/oira/services/surveys.py
+++ b/src/osha/oira/services/surveys.py
@@ -1,0 +1,83 @@
+from Acquisition import aq_chain
+from Acquisition import aq_inner
+from plone import api
+from plone.restapi.serializer.converters import json_compatible
+from plone.restapi.services import Service
+
+
+class ToolVersionsGet(Service):
+    """Get info from the containing tool and its versions.
+
+    From the Quaive side we request this.
+    Then we know if we are on a path that is within a survey group,
+    and we can show info about the versions, if we want.
+
+    This is meant to show information about versions like on the left
+    in the prototype:
+    https://proto.quaivecloud.com/tools/audio-visual-productions/edit
+
+    We need this information in the sidebar.
+    And we don't yet have a way of knowing what the "remote" portal_type
+    is of the path we are viewing in Quaive, so we don't know if we are
+    currently viewing a country or survey group or survey or risk.
+    So from the Quaive side we have no idea if we should show this version
+    information.  An extra REST API service then seems a good way to me.
+    """
+
+    def get_survey_info(self, survey):
+        return {
+            "@id": survey.absolute_url(),
+            "id": survey.id,
+            "title": survey.Title(),
+            "review_state": api.content.get_state(obj=survey),
+            "created": json_compatible(survey.created()),
+            "modified": json_compatible(survey.modified()),
+            "published": json_compatible(survey.published),
+        }
+
+    def reply(self):
+        obj = aq_inner(self.context)
+        # First gather basic info about the context and request.
+        result = {
+            "@id": f"{obj.absolute_url()}/@tool-versions",
+            # "id": obj.id,
+            "@type": obj.portal_type,
+        }
+        survey = None
+        surveygroup = None
+        # Find nearest survey and survey group.
+        # One of these might be the current object as well.
+        for parent in aq_chain(obj):
+            portal_type = getattr(parent, "portal_type", "")
+            if not portal_type:
+                break
+            if portal_type == "euphorie.survey":
+                survey = parent
+            elif portal_type == "euphorie.surveygroup":
+                surveygroup = parent
+
+        if not surveygroup:
+            # We are outside of a survey group, nothing to see here.
+            return result
+
+        result["surveygroup"] = {
+            "@id": surveygroup.absolute_url(),
+            "title": surveygroup.Title(),
+        }
+        if survey:
+            current_survey_id = survey.id
+            result["survey"] = self.get_survey_info(survey)
+        else:
+            current_survey_id = None
+        items = []
+        # TODO Can we know which survey is the main currently published one?
+        # When publishing a survey you get this question: "Are you sure you want
+        # to publish this OiRA Tool version? This will replace the current version."
+        # But afterwards both the old and new version have review_state 'published'.
+        for survey in surveygroup.contentValues():
+            if survey.id == current_survey_id:
+                # This is the survey on which path we are.
+                continue
+            items.append(self.get_survey_info(survey))
+        result["items"] = items
+        return result


### PR DESCRIPTION
Sample contents if you are on a survey group with two surveys:

```
{
  "@id": "http://localhost:8000/tool-creator/sectors/eu/covid-19/covid-19/@tool-versions",
  "@type": "euphorie.surveygroup",
  "items": [
    {
      "@id": "http://localhost:8000/tool-creator/sectors/eu/covid-19/covid-19/oira-tool-import",
      "created": "2021-05-28T08:14:51+00:00",
      "id": "oira-tool-import",
      "modified": "2022-09-30T13:48:45+00:00",
      "published": "2021-08-30T11:57:27",
      "review_state": "published",
      "title": "OiRA Tool import"
    },
    {
      "@id": "http://localhost:8000/tool-creator/sectors/eu/covid-19/covid-19/second-version-based-on-import",
      "created": "2021-05-28T08:14:51+00:00",
      "id": "second-version-based-on-import",
      "modified": "2024-06-07T08:59:54+00:00",
      "published": "2024-07-19T18:26:05",
      "review_state": "published",
      "title": "Second version based on import"
    }
  ],
  "surveygroup": {
    "@id": "http://localhost:8000/tool-creator/sectors/eu/covid-19/covid-19",
    "title": "COVID-19"
  }
}
```

Sample contents when you are on a survey and it has one sibling:

```
{
  "@id": "http://localhost:8000/tool-creator/sectors/eu/covid-19/covid-19/second-version-based-on-import/@tool-versions",
  "@type": "euphorie.survey",
  "items": [
    {
      "@id": "http://localhost:8000/tool-creator/sectors/eu/covid-19/covid-19/oira-tool-import",
      "created": "2021-05-28T08:14:51+00:00",
      "id": "oira-tool-import",
      "modified": "2022-09-30T13:48:45+00:00",
      "published": "2021-08-30T11:57:27",
      "review_state": "published",
      "title": "OiRA Tool import"
    }
  ],
  "survey": {
    "@id": "http://localhost:8000/tool-creator/sectors/eu/covid-19/covid-19/second-version-based-on-import",
    "created": "2021-05-28T08:14:51+00:00",
    "id": "second-version-based-on-import",
    "modified": "2024-06-07T08:59:54+00:00",
    "published": "2024-07-19T18:26:05",
    "review_state": "published",
    "title": "Second version based on import"
  },
  "surveygroup": {
    "@id": "http://localhost:8000/tool-creator/sectors/eu/covid-19/covid-19",
    "title": "COVID-19"
  }
}
```

We probably need more info or less.  But it's a nice start.

Let me paste what I have put in the docstring of this service, as explanation.

> From the Quaive side we request this.  Then we know if we are on a path that is within a survey group, and we can show info about the versions, if we want.
>
> This is meant to show information about versions like on the left in the prototype: https://proto.quaivecloud.com/tools/audio-visual-productions/edit
>
> We need this information in the sidebar.  And we don't yet have a way of knowing what the "remote" portal_type is of the path we are viewing in Quaive, so we don't know if we are currently viewing a country or survey group or survey or risk.  So from the Quaive side we have no idea if we should show this version information.  An extra REST API service then seems a good way to me.