### PR TITLE
Simplify the quaive-publish page.

### DIFF
--- a/src/osha/oira/ploneintranet/quaive_publish.py
+++ b/src/osha/oira/ploneintranet/quaive_publish.py
@@ -1,7 +1,5 @@
-from euphorie.client import MessageFactory as _
 from euphorie.client.browser.publish import PublishSurvey
 from osha.oira.ploneintranet.quaive_mixin import QuaiveEditFormMixin
-from z3c.form import button
 
 
 class PublishSurveyQuaiveForm(QuaiveEditFormMixin, PublishSurvey):
@@ -44,19 +42,3 @@ class PublishSurveyQuaiveForm(QuaiveEditFormMixin, PublishSurvey):
     I think this should change the review state of the previous survey to
     'draft' though.  Or really of all sibling surveys (tool versions).
     """
-
-    def nextURL(self):
-        return f"{self.context.absolute_url()}/@@quaive-edit"
-
-    @button.buttonAndHandler(_("button_publish", default="Publish"))
-    def handlePublish(self, action):
-        # Call our super.  Due to the @button we need to add 'self' in the call.
-        # The super calls 'self.publish', adds a status message, and redirects to
-        # the standard view.  We want a different redirect.  And note that currently
-        # the status message is not shown in Quaive.
-        super().handlePublish(self, action)
-        self.request.response.redirect(self.nextURL())
-
-    @button.buttonAndHandler(_("button_cancel", default="Cancel"))
-    def handleCancel(self, action):
-        self.request.response.redirect(self.nextURL())

--- a/src/osha/oira/ploneintranet/templates/quaive-publish.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-publish.pt
@@ -1,68 +1,33 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-      xmlns:meta="http://xml.zope.org/namespaces/meta"
-      xmlns:metal="http://xml.zope.org/namespaces/metal"
-      xmlns:tal="http://xml.zope.org/namespaces/tal"
-      meta:interpolation="true"
-      metal:use-macro="context/@@layout/macros/layout"
-      i18n:domain="euphorie"
+<tal:comment condition="TODO|nothing">
+  This is copied from 'euphorie.client.browser.templates.publish.pt'.
+  It could be nice to have these texts shared.
+</tal:comment>
+<div id="quaive-content"
+     i18n:domain="euphorie"
 >
-  <head>
-    <metal:meta use-macro="webhelpers/macros/headers" />
-  </head>
-  <body>
-    <metal:title fill-slot="title"
-                 i18n:translate="header_publish"
-    >Publish OiRA Tool</metal:title>
-    <metal:content fill-slot="content">
-      <form class="pat-form pat-inject"
-            action="${request/getURL}"
-            enctype="${view/enctype}"
-            method="${view/method}"
-            data-pat-inject="#content #application-body &amp;&amp; #application-body #application-body"
-      >
-        <p tal:condition="not:view/is_surveygroup_published"
-           i18n:translate="intro_publish_first_time"
-        >Are you sure you want to publish this OiRA Tool? After publication
-          the OiRA Tool will appear in the online client and be accessible by all users.</p>
-        <tal:block condition="view/is_surveygroup_published">
-          <p tal:condition="view/is_this_survey_published"
-             i18n:translate="intro_publish_survey_published"
-          >Are you sure you want to republish this OiRA Tool? This will make
-            all changes made public.</p>
-          <p tal:condition="not:view/is_this_survey_published"
-             i18n:translate="intro_publish_other_survey_published"
-          >Are you sure you want to publish this OiRA Tool version? This will
-            replace the current version.</p>
-          <p class="message warning"
-             tal:condition="view/is_structure_changed"
-             i18n:translate="intro_publish_survey_structure_changed"
-          >
-            The structure of your OiRA tool has changed. If you publish now, existing users of this OiRA tool will lose parts of their answers. Please contact the OiRA team if you need assistance on this subject. You can also refer to the chapter &ldquo;Re-working a published OiRA tool&rdquo; of the OiRA manual.
-          </p>
-        </tal:block>
-
-        <p i18n:translate="help_publish_url">After publication the OiRA Tool will be available at
-          <strong i18n:name="url">${view/client_url}</strong>.</p>
-
-        <div class="buttonBar"
-             tal:define="
-               actions view/actions/values|nothing;
-             "
-             tal:condition="actions"
-        >
-          <tal:action repeat="action actions">
-            <button class="pat-button float-after ${python: 'default' if repeat.action.index == 0 else ''}"
-                    name="${action/name}"
-                    type="submit"
-                    value="${action/title}"
-            >
-                  ${action/title}
-            </button>
-          </tal:action>
-        </div>
-      </form>
-    </metal:content>
-  </body>
-</html>
+  <p tal:condition="not:view/is_surveygroup_published"
+     i18n:translate="intro_publish_first_time"
+  >Are you sure you want to publish this OiRA Tool? After publication
+    the OiRA Tool will appear in the online client and be accessible by all users.</p>
+  <tal:block condition="view/is_surveygroup_published">
+    <p tal:condition="view/is_this_survey_published"
+       i18n:translate="intro_publish_survey_published"
+    >Are you sure you want to republish this OiRA Tool? This will make
+      all changes made public.</p>
+    <p tal:condition="not:view/is_this_survey_published"
+       i18n:translate="intro_publish_other_survey_published"
+    >Are you sure you want to publish this OiRA Tool version? This will
+      replace the current version.</p>
+    <p class="message warning"
+       tal:condition="view/is_structure_changed"
+       i18n:translate="intro_publish_survey_structure_changed"
+    >The structure of your OiRA tool has changed.
+     If you publish now, existing users of this OiRA tool will lose parts of their answers.
+     Please contact the OiRA team if you need assistance on this subject.
+      You can also refer to the chapter &ldquo;Re-working a published OiRA tool&rdquo; of the OiRA manual.</p>
+  </tal:block>
+  <tal:comment condition="nothing">We must generate the authenticator token on this side.</tal:comment>
+  <p i18n:translate="help_publish_url">After publication the OiRA Tool will be available at
+    <strong i18n:name="url">${view/client_url}</strong>.</p>
+  <span tal:replace="structure context/@@authenticator/authenticator"></span>
+</div>


### PR DESCRIPTION
The template only needs to show the texts and get the authenticator. And the upstream form in Euphorie should still handle the publish POST request.