### PR TITLE
update_user_languages_subscriber: do not fail when we cannot get portal

### DIFF
--- a/src/osha/oira/client/subscribers.py
+++ b/src/osha/oira/client/subscribers.py
@@ -36,9 +36,16 @@ def update_user_languages_subscriber(target, args, kwargs):
     if "zodb_path" not in kwargs:
         return
     # kwargs["account_id"] can refer to the account of the session being cloned
-    account = get_current_account()
-    if not account:
+    try:
+        account = get_current_account()
+        if not account:
+            return
+        client = api.portal.get().client
+    except api.exc.CannotGetPortalError:
+        # In corner cases (usually unit tests) we may not have a portal.
+        # `get_current_account` will then fail, but maybe someone has mocked
+        # this call, so we catch the error on a few lines.
+        # See https://github.com/euphorie/Euphorie/pull/757
         return
-    client = api.portal.get().client
     tool = client.restrictedTraverse(str(kwargs["zodb_path"]), None)
     update_user_languages(account.id, tool)


### PR DESCRIPTION
This may happen in unit tests.  See https://github.com/euphorie/Euphorie/pull/757

Not too important perhaps, but I ran into an error while trying to run the Euphorie tests in a buildout using `osha.oira` and this gave three errors.  It would be good to have such tests pass, so we can be more sure that `osha.oira` does not break expectations in Euphorie.

Also, this makes it easier to test that a change in Euphorie works in the buildout with `osha.oira` and in pure Euphorie itself, where you may even be testing it an an older or newer Plone version.