### PR TITLE
Define the tool-versions endpoint only for survey group.

### DIFF
--- a/src/osha/oira/services/configure.zcml
+++ b/src/osha/oira/services/configure.zcml
@@ -6,7 +6,7 @@
   <plone:service
       method="GET"
       factory=".surveys.ToolVersionsGet"
-      for="plone.dexterity.interfaces.IDexterityContainer"
+      for="euphorie.content.surveygroup.ISurveyGroup"
       permission="zope2.View"
       layer="osha.oira.interfaces.IOSHAContentSkinLayer"
       name="@tool-versions"


### PR DESCRIPTION
Simplify the structure we return:

* old when called on survey group: keys `surveygroup` and `items` (all surveys)
* old when called on survey: keys `surveygroup`, `survey` (the survey on the current request path), and `items` (the other surveys)
* new: the main dict contains the info on the survey group, and all surveys are in the `versions` key

This needs a change on the Quaive side, I will push a PR there next.