### PR TITLE
Add the @@survey-group-image view

### DIFF
--- a/src/osha/oira/content/browser/configure.zcml
+++ b/src/osha/oira/content/browser/configure.zcml
@@ -3,6 +3,12 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     >
 
+  <browser:resourceDirectory
+      name="osha.oira.content"
+      directory="resources"
+      layer="osha.oira.interfaces.IOSHAContentSkinLayer"
+      />
+
   <browser:page
       name="manage-ldap-users"
       for="euphorie.content.country.ICountry"
@@ -64,6 +70,14 @@
         permission="zope2.View"
         />
   </configure>
+
+  <browser:page
+      name="survey-group-image"
+      for="euphorie.content.surveygroup.ISurveyGroup"
+      class=".surveygroup.SurveyGroupImage"
+      permission="zope2.View"
+      layer="osha.oira.interfaces.IOSHAContentSkinLayer"
+      />
 
   <!-- Sector -->
   <adapter

--- a/src/osha/oira/content/browser/resources/clipboard.svg
+++ b/src/osha/oira/content/browser/resources/clipboard.svg
@@ -1,0 +1,6 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="66" height="74">
+<path d="M0,0 L5,0 L10,4 L10,12 L-4,12 L-4,4 L-1,3 Z M1,2 Z " fill="#000000" transform="translate(29,8)"/>
+<path d="M0,0 L7,0 L8,6 L10,7 L22,7 L24,6 L25,0 L32,0 L33,2 L33,9 L26,19 L25,20 L5,20 L6,22 L23,23 L20,27 L6,28 L5,30 L17,31 L18,38 L25,36 L32,27 L33,27 L33,40 L30,43 L1,43 L-1,41 L-1,1 Z M6,12 L5,15 L26,15 L26,12 Z " fill="#000000" transform="translate(16,15)"/>
+<path d="M0,0 L4,2 L3,6 L-8,22 L-11,22 L-13,21 L-12,17 L-1,1 Z " fill="#000000" transform="translate(52,23)"/>
+<path d="M0,0 L5,3 L3,6 L-1,5 Z " fill="#000000" transform="translate(36,45)"/>
+</svg>


### PR DESCRIPTION
This view is necessary to retrieve the image for the survey group in the best possible way, given the constraints.

Survey groups are assigned via a script across all survey versions (see https://github.com/syslabcom/scrum/issues/2552 for details).

The view redirects to the first meaningful image it can find. While this approach helps achieve the desired functionality, it is more of a workaround and isn't highly efficient. One downside is that browser caching may retain the image longer than intended, potentially affecting freshness.

This solution is a trade-off between performance and practicality.