### PR TITLE
Make the radio input widget understand rich terms

### DIFF
--- a/src/osha/oira/ploneintranet/z3cform/templates/radio_input.pt
+++ b/src/osha/oira/ploneintranet/z3cform/templates/radio_input.pt
@@ -13,20 +13,42 @@
   >
     <p class="legend">${view/label}</p>
     <div class="pat-checklist">
-      <label tal:repeat="item view/items">
-        ${item/label}
-        <input id="${item/id}"
-               checked="${python:'checked' if checked else None}"
-               disabled="${view/disabled}"
-               name="${item/name}"
-               readonly="${view/readonly}"
-               type="radio"
-               value="${item/value}"
-               tal:define="
-                 checked item/checked;
-               "
-        />
-      </label>
+
+      <tal:items repeat="item view/items">
+        <tal:item define="
+                    term python: view.terms.getTermByToken(item['value']);
+                    description term/description|nothing;
+                    extra_help term/extra_help|nothing;
+                  ">
+          <label>
+            ${item/label}
+            <input id="${item/id}"
+                   checked="${python:'checked' if checked else None}"
+                   disabled="${view/disabled}"
+                   name="${item/name}"
+                   readonly="${view/readonly}"
+                   type="radio"
+                   value="${item/value}"
+                   tal:define="
+                     checked item/checked;
+                   "
+            />
+            <dfn class="help-icon pat-tooltip tooltip-inactive"
+                 aria-expanded="false"
+                 title="Information"
+                 data-pat-tooltip="class: info; trigger: click; source: content; position-list: tl"
+                 tal:condition="extra_help"
+                 i18n:attributes="title"
+            >${extra_help}</dfn>
+          </label>
+          <p class="pat-message notice"
+             tal:condition="description"
+          >
+            ${description}
+          </p>
+
+        </tal:item>
+      </tal:items>
       <tal:error condition="view/error"
                  replace="structure view/error/render|nothing"
       />


### PR DESCRIPTION
See:

- https://github.com/euphorie/NuPlone/pull/51
- https://github.com/euphorie/Euphorie/pull/743

This patch brings the same feature to the widget shown in Quaive

Refs.: https://github.com/syslabcom/scrum/issues/2592