### PR TITLE
Reindex managerRolesAndUsers when managing ldap users

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,9 @@ Changelog
 10.0.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Update admin index when managing ldap users. 
+  (`#2640 <https://github.com/syslabcom/scrum/issues/2640>`_)
+  [reinhardt]
 
 
 10.0.1 (2024-08-02)

--- a/src/osha/oira/content/browser/manage_ldap_users.py
+++ b/src/osha/oira/content/browser/manage_ldap_users.py
@@ -83,6 +83,7 @@ class BaseManageLDAPUsersView(BrowserView):
             self.grant_roles(user)
         elif ldap_action == "revoke":
             self.revoke_roles(user)
+        self.context.reindexObject(idxs=["managerRolesAndUsers"])
 
     def __call__(self):
         self.maybe_manage_local_roles()


### PR DESCRIPTION
Note that the index is not updated when assigning permissions in another way. Hoping that this is enough for osha.

Ref syslabcom/scrum#2640