### PR TITLE
First attempt for aligning the tiptap toolbar with prototype

### DIFF
--- a/src/osha/oira/ploneintranet/configure.zcml
+++ b/src/osha/oira/ploneintranet/configure.zcml
@@ -6,6 +6,17 @@
 
   <include package=".z3cform" />
 
+  <configure package="euphorie.client.browser">
+    <browser:page
+        name="webhelpers"
+        for="*"
+        class="osha.oira.client.browser.webhelpers.OSHAWebHelpers"
+        template="templates/webhelpers.pt"
+        permission="zope.Public"
+        layer="osha.oira.interfaces.IOSHAContentSkinLayer"
+        />
+  </configure>
+
   <browser:page
       name="quaive-edit"
       for="euphorie.content.country.ICountry"

--- a/src/osha/oira/ploneintranet/templates/quaive-form.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-form.pt
@@ -7,6 +7,7 @@
       metal:use-macro="context/@@layout/macros/layout"
       tal:define="
         actions view/actions/values|nothing;
+        webhelpers nocall:context/@@webhelpers;
       "
       i18n:domain="nuplone"
 >
@@ -24,22 +25,18 @@
               source: #sidebar-assessments; target: #sidebar-assessments
             "
       >
-        <div class="pat-toolbar sticky"
-             id="sector-toolbar"
-        >
-          <div class="toolbar-functions-area pat-inject pat-form pat-autosubmit"
-               id="toolbar-functions-area-assessments"
-          >
+
+        <metal:toolbar use-macro="webhelpers/macros/toolbar">
+          <metal:actions fill-slot="page-actions">
             <div class="toolbar-section quick-functions"
                  id="sector-toolbar-quick-functions"
             >
               <tal:action repeat="action python: reversed(actions)"
                           replace="structure action/render"
               />
-
             </div>
-          </div>
-        </div>
+          </metal:actions>
+        </metal:toolbar>
 
         <div class="container">
           <div class="pat-well">

--- a/src/osha/oira/ploneintranet/z3cform/templates/wysiwyg_input.pt
+++ b/src/osha/oira/ploneintranet/z3cform/templates/wysiwyg_input.pt
@@ -15,76 +15,6 @@
       <span tal:replace="view/label"></span>
     </legend>
 
-    <div class="editor-toolbar tiptap canvas-toolbar"
-         id="texteditor-toolbar-${view/id}"
-    >
-
-      <button class="button-undo icon icon-ccw pat-tooltip"
-              type="button"
-              data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
-              i18n:translate=""
-      >Undo</button>
-
-      <button class="button-redo icon icon-cw pat-tooltip"
-              type="button"
-              data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
-              i18n:translate=""
-      >Redo</button>
-
-      <a class="icon icon-html5 button-source pat-modal pat-tooltip"
-         href="#tiptap-modal-source-editor--fieldname-${view/id}"
-         data-pat-modal="class: medium panel html-source-editor panel-html-source-editor"
-         data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
-         i18n:translate=""
-      >Code</a>
-
-      <button class="icon icon-bold button-bold pat-tooltip"
-              type="button"
-              data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
-              i18n:translate=""
-      >Bold</button>
-      <button class="icon icon-italic button-italic pat-tooltip"
-              type="button"
-              data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
-              i18n:translate=""
-      >Italic</button>
-
-      <div class="pat-collapsible pat-context-menu closed align-left no-label icon-list"
-           id="list-menu"
-           type="button"
-           data-pat-collapsible="close-trigger: .pat-context-menu:not(#list-menu),.close-menu;"
-      >
-        <strong class="context-menu-label menu-trigger pat-tooltip"
-                data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
-                i18n:translate=""
-        >Lists</strong>
-        <p class="close-menu"
-           i18n:translate=""
-        >Close</p>
-        <ul class="menu-list">
-          <li>
-            <button class="button-unordered-list icon-list-bullet"
-                    type="button"
-                    i18n:translate=""
-            >Bullet list</button>
-          </li>
-          <li>
-            <button class="button-ordered-list icon-list-numbered"
-                    type="button"
-                    i18n:translate=""
-            >Ordered list</button>
-          </li>
-        </ul>
-      </div>
-
-      <a class="icon icon-link button-link pat-modal pat-tooltip"
-         href="#tiptap-modal-hyperlink--fieldname-${view/id}"
-         data-pat-modal="class: medium panel panel-hyperlink"
-         data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
-         i18n:translate=""
-      >Hyperlink</a>
-    </div>
-
     <textarea class="${view/klass} pat-tiptap"
               id="${view/id}"
               cols="${view/cols}"
@@ -93,7 +23,7 @@
               readonly="${view/readonly}"
               rows="${view/rows}"
               data-pat-tiptap="
-                toolbar-external: #texteditor-toolbar-${view/id};
+                toolbar-external: #assessment-toolbar;
                 link-panel: #tiptap-model-hyperlink--fieldname-${view/id} .link-panel;
                 link-menu: #tiptap-context-menu-hyperlink--fieldname-${view/id};
                 source-panel: #tiptap-model-source-editor--fieldname-${view/id} .source-panel;


### PR DESCRIPTION
Ref: scrum-2611


First attempt of aligning the tiptap editor toolbar with prototype by using the already defined tiptap macro from Euphorie to avoid code duplication. The tiptap code can get quite lengthy.

But this approach is abandoned because:

- Euphories toolbar looks slightly different and includes a toggle switch for an non-existing sidebar.
- Euphorie might have different requirements due to file/image uploading, embedding, etc
- Euphorie uses modals which are defined in shell.pt but the shell isn't used in Quoira.

I added this PR as reference in case we want to unify the editor experience throughout the project.

However, I suggest to factor out the tiptap editor code into a separate project like:

- slc.tiptap
- collective.tiptap
- plone.formwidget.tiptap

or some similar external package for better reuse.