### PR TITLE
Quoira: Align the tiptap toolbar with prototype

### DIFF
--- a/src/osha/oira/ploneintranet/templates/quaive-form.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-form.pt
@@ -24,19 +24,202 @@
               source: #sidebar-assessments; target: #sidebar-assessments
             "
       >
-        <div class="pat-toolbar sticky"
-             id="sector-toolbar"
-        >
-          <div class="toolbar-functions-area pat-inject pat-form pat-autosubmit"
-               id="toolbar-functions-area-assessments"
-          >
+
+        <!--! Editing toolbar -->
+        <div class="pat-toolbar sticky">
+          <div class="toolbar-functions-area">
+
+            <div class="toolbar-section editor">
+              <div class="editor-toolbar tiptap"
+                    id="editor-toolbar">
+
+                <div class="pat-collapsible pat-context-menu formatting-menu align-left no-label icon-paragraph closed"
+                     data-pat-collapsible="
+                        store: none;
+                        scroll-selector: none;
+                        trigger: #context-menu-trigger-formatting-editor-toolbar;
+                        close-trigger: .context-menu:not(.formatting-menu),.close-menu;"
+                >
+                  <strong class="context-menu-label menu-trigger pat-tooltip"
+                          id="context-menu-trigger-formatting-editor-toolbar"
+                          data-pat-tooltip="
+                            trigger: hover;
+                            source: content;
+                            position-list: tm;
+                            class: label"
+                          i18n:translate=""
+                  >Formatting</strong>
+                  <div class="panel-content">
+                    <p class="close-menu">Close</p>
+                    <ul class="menu-list">
+                      <li>
+                        <button class="button-heading-level-2 icon-header"
+                                type="button"
+                        >Header level 2</button>
+                      </li>
+                      <li>
+                        <button class="button-heading-level-3 icon-header"
+                                type="button"
+                        >Header level 3</button>
+                      </li>
+                      <li>
+                        <button class="button-heading-level-4 icon-header"
+                                type="button"
+                        >Header level 4</button>
+                      </li>
+                      <li>
+                        <button class="button-paragraph icon-paragraph"
+                                type="button"
+                        >Normal</button>
+                      </li>
+                      <li>
+                        <button class="button-blockquote icon-quote-left"
+                                type="button"
+                        >Quote</button>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+
+                <button class="icon icon-bold button-bold pat-tooltip"
+                        type="button"
+                        data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
+                >Bold</button>
+
+                <button class="icon icon-italic button-italic pat-tooltip"
+                        type="button"
+                        data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
+                >Italic</button>
+
+                <button class="icon icon-strike button-strike pat-tooltip"
+                        type="button"
+                        data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
+                >Strikethrough</button>
+
+                <a class="icon icon-link button-link pat-modal pat-tooltip"
+                   href="#tiptap-modal-hyperlink"
+                   data-pat-modal="class: medium panel panel-hyperlink"
+                   data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
+                >Hyperlink</a>
+
+                <button class="button-horizontal-rule icon icon-minus pat-tooltip"
+                        type="button"
+                        data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
+                >Horizontal line</button>
+
+                <div class="pat-collapsible pat-context-menu list-menu closed align-left no-label icon-list"
+                     type="button"
+                     data-pat-collapsible="
+                        store: none;
+                        scroll-selector: none;
+                        trigger: #context-menu-trigger-list-editor-toolbar;
+                        close-trigger: .context-menu:not(.list-menu),.close-menu;"
+                >
+                  <strong class="context-menu-label menu-trigger pat-tooltip"
+                          id="context-menu-trigger-list-editor-toolbar"
+                          data-pat-tooltip="
+                            trigger: hover;
+                            source: content;
+                            position-list: tm;
+                            class: label"
+                  >Lists</strong>
+                  <div class="panel-content">
+                    <p class="close-menu">Close</p>
+                    <ul class="menu-list">
+                      <li>
+                        <button class="button-unordered-list icon-list-bullet"
+                                type="button"
+                        >Bullet list</button>
+                      </li>
+                      <li>
+                        <button class="button-ordered-list icon-list-numbered"
+                                type="button"
+                        >Ordered liste</button>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+
+                <a class="icon icon-picture-1 button-image pat-modal pat-tooltip"
+                   href="#tiptap-modal-image"
+                   data-pat-modal="class: large panel image-picker"
+                   data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
+                >Picture</a>
+
+                <a class="icon icon-video button-embed pat-modal pat-tooltip"
+                   href="#tiptap-modal-embed"
+                   data-pat-modal="class: medium panel embed-video"
+                   data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
+                >Video</a>
+
+                <div class="pat-collapsible pat-context-menu closed align-right table-menu no-label icon-table"
+                     id="table-menu-editor-toolbar"
+                     data-pat-collapsible="
+                        store: none;
+                        scroll-selector: none;
+                        trigger: #context-menu-trigger-table-editor-toolbar;
+                        close-trigger: .context-menu:not(.table-menu),.close-menu;"
+                >
+                  <strong class="context-menu-label menu-trigger pat-tooltip"
+                          id="context-menu-trigger-table-editor-toolbar"
+                          data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
+                  >Table</strong>
+                  <div class="panel-content">
+                    <p class="close-menu">Close</p>
+                    <ul class="menu-list">
+                      <li>
+                        <button class="button-table-create icon-plus-squared"
+                                type="button"
+                        >New table</button>
+                      </li>
+                      <li>
+                        <button class="button-table-remove icon-minus-squared"
+                                type="button"
+                        >Remove table</button>
+                      </li>
+                      <li>
+                        <button class="button-table-add-column-left icon-add-column-left"
+                                type="button"
+                        >Add left column</button>
+                      </li>
+                      <li>
+                        <button class="button-table-add-column-right icon-add-column"
+                                type="button"
+                        >Add right columnt</button>
+                      </li>
+                      <li>
+                        <button class="button-table-remove-column icon-remove-column"
+                                type="button"
+                        >Remove column</button>
+                      </li>
+                      <li>
+                        <button class="button-table-add-row-above icon-add-row-above"
+                                type="button"
+                        >Add top row</button>
+                      </li>
+                      <li>
+                        <button class="button-table-add-row-below icon-add-row"
+                                type="button"
+                        >Add bottom row</button>
+                      </li>
+                      <li>
+                        <button class="button-table-remove-row icon-remove-row"
+                                type="button"
+                        >Remove row</button>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+
+              </div>
+
+            </div>
             <div class="toolbar-section quick-functions"
-                 id="sector-toolbar-quick-functions"
+                 id="module-toolbar-quick-functions"
             >
               <tal:action repeat="action python: reversed(actions)"
                           replace="structure action/render"
               />
-
             </div>
           </div>
         </div>
@@ -131,6 +314,223 @@
                value="${python: view.__name__.rpartition('-')[-1]}"
         />
       </form>
+
+      <!-- modal image editor -->
+      <template id="tiptap-modal-image">
+        <h1>Edit Image</h1>
+        <div class="panel-body image-panel">
+          <div class="container">
+            <form class="pat-form">
+              <fieldset class="horizontal">
+                <label class="image-url">
+                  <tal:i18n i18n:translate="">Image URL</tal:i18n>
+                  <span class="button-field type-url">
+                    <input class="pat-autofocus"
+                           name="tiptap-src"
+                           oninput="if (this.value) { this.nextElementSibling.href = this.value; } else { this.nextElementSibling.removeAttribute('href'); }"
+                           type="url"
+                           value=""
+                    />
+                    <a class="follow"
+                       id="event-url-follow-button"
+                       href=""
+                       target="_blank"
+                       title="Visit linked web page"
+                       i18n:attributes="title"
+                       i18n:translate=""
+                    >Follow</a>
+                  </span>
+                </label>
+                <label class="image-title">
+                  <tal:i18n i18n:translate="">Title</tal:i18n>
+                  <input name="tiptap-title"
+                         type="text"
+                  />
+                </label>
+                <label class="image-alt">
+                  <tal:i18n i18n:translate="">Alternative text</tal:i18n>
+                  <input name="tiptap-alt"
+                         type="text"
+                  />
+                </label>
+                <label class="image-caption">
+                  <tal:i18n i18n:translate="">Image caption</tal:i18n>
+                  <textarea name="tiptap-caption"></textarea>
+                </label>
+              </fieldset>
+            </form>
+            <div class="buttons button-bar pat-bumper">
+              <button class="pat-button default close-panel icon-ok-circle"
+                      name="tiptap-confirm"
+                      type="submit"
+                      i18n:translate=""
+              >Insert</button>
+              <button class="pat-button close-panel icon-cancel-circle"
+                      type="button"
+                      i18n:translate=""
+              >Cancel</button>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <!-- context menu image -->
+      <template id="context-menu-image">
+        <ul class="menu tiptap-image-context-menu">
+          <li>
+            <button
+              type="button"
+              class="close-panel tiptap-edit-image">Edit image</button>
+          </li>
+          <li>
+            <button
+              type="button"
+              class="close-panel tiptap-remove-image">Remove image</button>
+          </li>
+        </ul>
+      </template>
+
+      <!-- modal embed editor -->
+      <template id="tiptap-modal-embed">
+        <h1>Edit Embed</h1>
+        <div class="panel-body embed-panel">
+          <div class="container">
+            <form class="pat-form">
+              <fieldset class="horizontal">
+                <label class="embed-url">
+                  <tal:i18n i18n:translate="">Video/Audio URL</tal:i18n>
+                  <span class="button-field type-url">
+                    <input class="pat-autofocus"
+                           name="tiptap-src"
+                           oninput="if (this.value) { this.nextElementSibling.href = this.value; } else { this.nextElementSibling.removeAttribute('href'); }"
+                           type="url"
+                           value=""
+                    />
+                    <a class="follow"
+                       id="event-url-follow-button"
+                       href=""
+                       target="_blank"
+                       title="Visit linked web page"
+                       i18n:attributes="title"
+                       i18n:translate=""
+                    >Follow</a>
+                  </span>
+                </label>
+                <label class="embed-title">
+                  <tal:i18n i18n:translate="">Title</tal:i18n>
+                  <input name="tiptap-title"
+                         type="text"
+                  />
+                </label>
+                <label class="embed-caption">
+                  <tal:i18n i18n:translate="">Video/Audio caption</tal:i18n>
+                  <textarea name="tiptap-caption"></textarea>
+                </label>
+              </fieldset>
+            </form>
+            <div class="buttons button-bar pat-bumper">
+              <button class="pat-button default close-panel icon-ok-circle"
+                      name="tiptap-confirm"
+                      type="submit"
+                      i18n:translate=""
+              >Insert</button>
+              <button class="pat-button close-panel icon-cancel-circle"
+                      type="button"
+                      i18n:translate=""
+              >Cancel</button>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <!-- context menu embed -->
+      <template id="context-menu-embed">
+        <ul class="menu tiptap-embed-context-menu">
+          <li>
+            <button
+              type="button"
+              class="close-panel tiptap-edit-embed">Edit embed</button>
+          </li>
+          <li>
+            <button
+              type="button"
+              class="close-panel tiptap-remove-embed">Remove embed</button>
+          </li>
+        </ul>
+      </template>
+
+      <!-- modal link editor -->
+      <template id="tiptap-modal-hyperlink">
+        <h1>Edit Link</h1>
+        <div class="panel-body embed-panel">
+          <div class="container">
+            <form class="pat-form">
+              <fieldset class="horizontal">
+                <label class="url">
+                  <tal:i18n i18n:translate="">URL</tal:i18n>
+                  <span class="button-field type-url">
+                    <input class="pat-autofocus"
+                           name="tiptap-href"
+                           oninput="if (this.value) { this.nextElementSibling.href = this.value; } else { this.nextElementSibling.removeAttribute('href'); }"
+                           type="url"
+                           value=""
+                    />
+                    <a class="follow"
+                       id="event-url-follow-button"
+                       href=""
+                       target="_blank"
+                       title="Visit linked web page"
+                       i18n:attributes="title"
+                       i18n:translate=""
+                    >Follow</a>
+                  </span>
+                </label>
+                <label class="url--text">
+                  <tal:i18n i18n:translate="">Link text</tal:i18n>
+                  <input name="tiptap-text"
+                         type="text"
+                  />
+                </label>
+              </fieldset>
+            </form>
+            <div class="buttons button-bar pat-bumper">
+              <button class="pat-button default close-panel icon-ok-circle"
+                      name="tiptap-confirm"
+                      type="submit"
+                      i18n:translate=""
+              >Insert</button>
+              <button class="pat-button close-panel icon-cancel-circle"
+                      type="button"
+                      i18n:translate=""
+              >Cancel</button>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <!-- context menu link -->
+      <template id="tiptap-context-menu-hyperlink">
+        <ul class="menu tiptap-link-context-menu">
+          <li>
+            <a class="icon-link close-panel tiptap-open-new-link"
+               href=""
+               target="_blank"
+               i18n:translate=""
+            >Visit linked web page</a>
+          </li>
+          <li>
+            <a class="icon-pencil close-panel tiptap-edit-link"
+               i18n:translate=""
+            >Edit link</a>
+          </li>
+          <li>
+            <a class="icon-unlink close-panel tiptap-unlink"
+               i18n:translate=""
+            >Unlink</a>
+          </li>
+        </ul>
+      </template>
+
     </div>
   </metal:content>
 </html>

--- a/src/osha/oira/ploneintranet/templates/quaive-form.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-form.pt
@@ -225,73 +225,88 @@
         </div>
 
         <div class="container">
-          <div class="pat-well">
+
+          <div class="pat-well pat-collapsible borderless open"
+               id="fieldset--${view/id}"
+               data-pat-collapsible="
+                   trigger: #well-header--${view/id};
+                   store: local;
+                   scroll-selector: self;
+                   scroll-offset: 120px;
+               "
+          >
             <div class="well-title-group">
-              <h2 class="well-header">${view/label}</h2>
+              <h2 class="well-header"
+                  id="well-header--${view/id}">
+                  ${view/label}
+              </h2>
               <div class="buttons">
                 <dfn class="icon help help-icon pat-tooltip tooltip-active-click"
                      data-pat-tooltip="class: info; trigger: click; source: content; position-list: tl"
-                     tal:condition="python:getattr(view, 'description', None)"
+                     tal:define="
+                       description view/description;
+                     "
+                     tal:condition="description"
                 >
-                  ${view/description}
+                    ${description}
                 </dfn>
               </div>
             </div>
 
-            <p class="message ${python:'error' if view.widgets.errors else 'notice'}"
-               tal:define="
-                 status view/status;
-               "
-               tal:condition="status"
-               tal:content="status"
-               i18n:domain="plone"
-            >Form-global message</p>
-            <fieldset class="section horizontal">
-              <tal:widget tal:repeat="widget view/widgets/values">
-                <tal:widget define="
-                              error nocall: widget/error|nothing;
-                            ">
-                  ${structure: widget/render}
-                  <p class="pat-notice error"
-                     tal:condition="python: error"
-                  >
-                    ${structure: error/render}
-                  </p>
+            <div class="panel-content">
+              <p class="message ${python:'error' if view.widgets.errors else 'notice'}"
+                 tal:define="
+                   status view/status;
+                 "
+                 tal:condition="status"
+                 tal:content="status"
+                 i18n:domain="plone"
+              >Form-global message</p>
+              <fieldset class="section horizontal">
+                <tal:widget tal:repeat="widget view/widgets/values">
+                  <tal:widget define="
+                                error nocall: widget/error|nothing;
+                              ">
+                    ${structure: widget/render}
+                    <p class="pat-notice error"
+                       tal:condition="python: error"
+                    >
+                      ${structure: error/render}
+                    </p>
+                  </tal:widget>
                 </tal:widget>
-              </tal:widget>
-            </fieldset>
-
+              </fieldset>
+            </div>
           </div>
 
-          <div class="pat-page-module type-planned-measures pat-well pat-collapsible borderless open"
+          <div class="pat-well pat-collapsible borderless closed"
                id="fieldset-${group/__name__}"
                data-pat-collapsible="
-                store: local;
-                scroll-selector: self;
-                scroll-offset: 120px;
-                open-trigger: .expand-all-sections;
-                close-trigger: .collapse-all-sections;"
+                   trigger: #well-header--${group/__name__};
+                   store: local;
+                   scroll-selector: self;
+                   scroll-offset: 120px;
+               "
                tal:repeat="group view/groups|nothing"
           >
             <div class="well-title-group">
-              <h2 class="well-header">
-              ${group/label}
-                <div class="buttons">
-                  <dfn class="icon help help-icon pat-tooltip tooltip-active-click"
-                       data-pat-tooltip="class: info; trigger: click; source: content; position-list: tl"
-                       tal:define="
-                         description group/description;
-                       "
-                       tal:condition="description"
-                  >
-                  ${description}
-                  </dfn>
-                </div>
+              <h2 class="well-header"
+                  id="well-header--${group/__name__}">
+                  ${group/label}
               </h2>
+              <div class="buttons">
+                <dfn class="icon help help-icon pat-tooltip tooltip-active-click"
+                     data-pat-tooltip="class: info; trigger: click; source: content; position-list: tl"
+                     tal:define="
+                       description group/description;
+                     "
+                     tal:condition="description"
+                >
+                    ${description}
+                </dfn>
+              </div>
             </div>
-            <div class="panel-content"
-                 style=""
-            >
+            <div class="panel-content">
               <fieldset class="horizontal">
                 <tal:widget tal:repeat="widget group/widgets/values">
                   <tal:widget define="

--- a/src/osha/oira/ploneintranet/z3cform/templates/checkbox_input.pt
+++ b/src/osha/oira/ploneintranet/z3cform/templates/checkbox_input.pt
@@ -4,28 +4,37 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:define="
         dependencies nocall:view/@@dependencies;
+        label view/field/label_content|nothing;
       "
       tal:omit-tag=""
       i18n:domain="nuplone"
 >
-  <fieldset class="pat-toggle-switch group ${dependencies/ploneintranet_classes}"
+
+  <fieldset class="pat-form-field-toggle group ${dependencies/ploneintranet_classes}"
             data-pat-depends="${dependencies/data_pat_depends}"
   >
-    <p class="legend">
+    <legend>
       ${python: view.items[0]['label']}
-    </p>
-    <label tal:repeat="item view/items">${view/field/label_content|nothing}<input class="${view/klass}"
+    </legend>
+    <label class="pat-toggle-switch"
+           tal:repeat="item view/items"
+    >
+      <tal:if condition="label">
+          ${label}
+      </tal:if>
+      <tal:if condition="not:label">
+        <tal:i18n i18n:translate="">On</tal:i18n>
+      </tal:if>
+      <input class="${view/klass}"
              id="${view/id}"
-             checked="${python:'checked' if checked else None}"
+             checked="${python:'checked' if item['checked'] else None}"
              disabled="${view/disabled}"
              name="${item/name}"
              readonly="${view/readonly}"
              type="checkbox"
              value="${item/value}"
-             tal:define="
-               checked item/checked;
-             "
-      /></label>
+      />
+    </label>
     <input name="${view/name}-empty-marker"
            type="hidden"
            value="1"

--- a/src/osha/oira/ploneintranet/z3cform/templates/checkboxlist_input.pt
+++ b/src/osha/oira/ploneintranet/z3cform/templates/checkboxlist_input.pt
@@ -8,23 +8,30 @@
       tal:omit-tag=""
       i18n:domain="nuplone"
 >
-  <fieldset class="group ${dependencies/ploneintranet_classes}"
+  <fieldset class="pat-form-field-toggle group ${dependencies/ploneintranet_classes}"
             data-pat-depends="${dependencies/data_pat_depends}"
   >
-    <p class="legend">${view/label}</p>
+    <legend>
+      ${view/label}
+    </legend>
     <div class="pat-checklist">
-      <label tal:repeat="item view/items">
-        ${item/label}
-        <input id="${item/id}"
-               checked="${python:'checked' if checked else None}"
+      <label class="pat-toggle-switch"
+             tal:repeat="item view/items"
+      >
+        <tal:if condition="item/label">
+            ${item/label}
+        </tal:if>
+        <tal:if condition="not:item/label">
+          <tal:i18n i18n:translate="">On</tal:i18n>
+        </tal:if>
+        <input class="${view/klass}"
+               id="${item/id}"
+               checked="${python:'checked' if item['checked'] else None}"
                disabled="${view/disabled}"
                name="${item/name}"
                readonly="${view/readonly}"
                type="checkbox"
                value="${item/value}"
-               tal:define="
-                 checked item/checked;
-               "
         />
       </label>
       <input name="${view/name}-empty-marker"
@@ -33,5 +40,7 @@
       />
     </div>
     <metal:help use-macro="view/@@quaive_form_macros/help_tooltip" />
+
   </fieldset>
+
 </html>

--- a/src/osha/oira/ploneintranet/z3cform/templates/namedimage_input.pt
+++ b/src/osha/oira/ploneintranet/z3cform/templates/namedimage_input.pt
@@ -23,7 +23,8 @@
            readonly="${view/readonly}"
            type="file"
     />
-    <tal:has-image condition="view/allow_nochange"><img class="floatAfter"
+    <tal:has-image condition="view/allow_nochange">
+      <img class="floatAfter"
            alt=""
            src="${scale/url}"
            width="${scale/width}"

--- a/src/osha/oira/ploneintranet/z3cform/templates/wysiwyg_input.pt
+++ b/src/osha/oira/ploneintranet/z3cform/templates/wysiwyg_input.pt
@@ -8,201 +8,40 @@
       tal:omit-tag=""
       i18n:domain="nuplone"
 >
-  <fieldset class="group pat-rich ${dependencies/ploneintranet_classes}"
+
+  <fieldset class="group ${dependencies/ploneintranet_classes}"
             data-pat-depends="${dependencies/data_pat_depends}"
   >
     <legend title="${view/field/description}">
-      <span tal:replace="view/label"></span>
+      ${view/label}
     </legend>
 
-    <div class="editor-toolbar tiptap canvas-toolbar"
-         id="texteditor-toolbar-${view/id}"
-    >
+    <div class="pat-rich-editor toolbar-detached">
+      <div class="pat-rich">
 
-      <button class="button-undo icon icon-ccw pat-tooltip"
-              type="button"
-              data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
-              i18n:translate=""
-      >Undo</button>
+        <textarea class="${view/klass} pat-tiptap"
+                  id="${view/id}"
+                  cols="${view/cols}"
+                  disabled="${view/disabled}"
+                  name="${view/name}"
+                  readonly="${view/readonly}"
+                  rows="${view/rows}"
+                  data-pat-tiptap="
+                      toolbar-external: #editor-toolbar;
+                      link-panel: #tiptap-modal-hyperlink .link-panel;
+                      link-menu: #tiptap-context-menu-hyperlink;
+                      image-panel: #tiptap-modal-image .image-panel;
+                      image-menu: #context-menu-image;
+                      embed-panel: #tiptap-modal-embed .embed-panel;
+                      embed-menu: #context-menu-embed;
+                  "
+        >${view/value}</textarea>
 
-      <button class="button-redo icon icon-cw pat-tooltip"
-              type="button"
-              data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
-              i18n:translate=""
-      >Redo</button>
-
-      <a class="icon icon-html5 button-source pat-modal pat-tooltip"
-         href="#tiptap-modal-source-editor--fieldname-${view/id}"
-         data-pat-modal="class: medium panel html-source-editor panel-html-source-editor"
-         data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
-         i18n:translate=""
-      >Code</a>
-
-      <button class="icon icon-bold button-bold pat-tooltip"
-              type="button"
-              data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
-              i18n:translate=""
-      >Bold</button>
-      <button class="icon icon-italic button-italic pat-tooltip"
-              type="button"
-              data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
-              i18n:translate=""
-      >Italic</button>
-
-      <div class="pat-collapsible pat-context-menu closed align-left no-label icon-list"
-           id="list-menu"
-           type="button"
-           data-pat-collapsible="close-trigger: .pat-context-menu:not(#list-menu),.close-menu;"
-      >
-        <strong class="context-menu-label menu-trigger pat-tooltip"
-                data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
-                i18n:translate=""
-        >Lists</strong>
-        <p class="close-menu"
-           i18n:translate=""
-        >Close</p>
-        <ul class="menu-list">
-          <li>
-            <button class="button-unordered-list icon-list-bullet"
-                    type="button"
-                    i18n:translate=""
-            >Bullet list</button>
-          </li>
-          <li>
-            <button class="button-ordered-list icon-list-numbered"
-                    type="button"
-                    i18n:translate=""
-            >Ordered list</button>
-          </li>
-        </ul>
       </div>
-
-      <a class="icon icon-link button-link pat-modal pat-tooltip"
-         href="#tiptap-modal-hyperlink--fieldname-${view/id}"
-         data-pat-modal="class: medium panel panel-hyperlink"
-         data-pat-tooltip="trigger: hover; source: content; position-list: tm; class: label"
-         i18n:translate=""
-      >Hyperlink</a>
     </div>
 
-    <textarea class="${view/klass} pat-tiptap"
-              id="${view/id}"
-              cols="${view/cols}"
-              disabled="${view/disabled}"
-              name="${view/name}"
-              readonly="${view/readonly}"
-              rows="${view/rows}"
-              data-pat-tiptap="
-                toolbar-external: #texteditor-toolbar-${view/id};
-                link-panel: #tiptap-model-hyperlink--fieldname-${view/id} .link-panel;
-                link-menu: #tiptap-context-menu-hyperlink--fieldname-${view/id};
-                source-panel: #tiptap-model-source-editor--fieldname-${view/id} .source-panel;
-              "
-    >${view/value}</textarea>
     <metal:help use-macro="view/@@quaive_form_macros/help_tooltip" />
 
-    <!-- modal source editor -->
-    <template id="tiptap-modal-source-editor--fieldname-${view/id}">
-      <h1>Edit HTML</h1>
-      <div class="panel-body source-panel">
-        <div class="container">
-          <div class="html-source-panel-content">
-            <form>
-              <textarea class="pat-autofocus"
-                        name="tiptap-source"
-              ></textarea>
-            </form>
-          </div>
-          <div class="buttons button-bar pat-bumper"
-               id="modal-button-bar"
-          >
-            <button class="pat-button default close-panel icon-ok-circle"
-                    name="tiptap-confirm"
-                    type="button"
-                    i18n:translate=""
-            >Apply</button>
-            <button class="pat-button close-panel icon-cancel-circle"
-                    type="button"
-                    i18n:translate=""
-            >Cancel</button>
-          </div>
-        </div>
-      </div>
-    </template>
-
-    <!-- modal link editor -->
-    <template id="tiptap-modal-hyperlink--fieldname-${view/id}">
-      <h1>Edit Link</h1>
-      <div class="panel-body link-panel">
-        <div class="container">
-          <form class="pat-form">
-            <fieldset class="vertical">
-              <fieldset class="group url">
-                <legend i18n:translate="">URL</legend>
-                <span class="button-field type-url">
-                  <input class="pat-autofocus"
-                         name="tiptap-href"
-                         oninput="if (this.value) { this.nextElementSibling.href = this.value; } else { this.nextElementSibling.removeAttribute('href'); }"
-                         type="url"
-                         value=""
-                  />
-                  <a class="follow"
-                     id="event-url-follow-button"
-                     href=""
-                     target="_blank"
-                     title="Visit linked web page"
-                     i18n:attributes="title"
-                     i18n:translate=""
-                  >Follow</a>
-                </span>
-              </fieldset>
-              <label>
-                <tal:i18n i18n:translate="">Link text</tal:i18n>
-                <input name="tiptap-text"
-                       type="text"
-                />
-              </label>
-            </fieldset>
-          </form>
-          <div class="buttons button-bar pat-bumper"
-               id="modal-button-bar"
-          >
-            <button class="pat-button default close-panel icon-ok-circle"
-                    name="tiptap-confirm"
-                    type="submit"
-                    i18n:translate=""
-            >Insert</button>
-            <button class="pat-button close-panel icon-cancel-circle"
-                    type="button"
-                    i18n:translate=""
-            >Cancel</button>
-          </div>
-        </div>
-      </div>
-    </template>
-
-    <!-- context menu link -->
-    <template id="tiptap-context-menu-hyperlink--fieldname-${view/id}">
-      <ul class="menu tiptap-link-context-menu">
-        <li>
-          <a class="icon-link close-panel tiptap-open-new-link"
-             href=""
-             target="_blank"
-             i18n:translate=""
-          >Visit linked web page</a>
-        </li>
-        <li>
-          <a class="icon-pencil close-panel tiptap-edit-link"
-             i18n:translate=""
-          >Edit link</a>
-        </li>
-        <li>
-          <a class="icon-unlink close-panel tiptap-unlink"
-             i18n:translate=""
-          >Unlink</a>
-        </li>
-      </ul>
-    </template>
-
   </fieldset>
+
 </html>


### PR DESCRIPTION
Note: There is an alternative approach for reference which reuses the tiptap toolbar from Euphorie.
If we want to go the path of unifying I'd even recommend to separate the tiptap integration code into a separate package. https://github.com/euphorie/osha.oira/pull/293

This PR contains:

- Align tiptap texteditor to prototype.
  Ref: scrum-2611.

- Align checkbox with prototype layout.
  Ref: scrum-2883.

Plus:
- Prototype Alignment: Adapt layout of forms.
- Prototype alignment: Minor layout change.

Looks now like:

![image](https://github.com/user-attachments/assets/0f0e61c6-bc3c-4218-bc99-eb3295ae0022)