### PR TITLE
Restore the required state of conditional input fields.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,10 @@ Changelog
 10.0.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Restore the required state of conditional input fields.
+  pat-depends disables hidden input fields in action-mode "enable" and "both" since Patternslib 9.10.
+  Ref: scrum-2615.
+  [thet]
 
 
 10.0.3 (2024-10-30)

--- a/src/osha/oira/ploneintranet/z3cform/templates/conditional_text_input.pt
+++ b/src/osha/oira/ploneintranet/z3cform/templates/conditional_text_input.pt
@@ -31,7 +31,7 @@
            maxlength="${view/maxlength}"
            name="${view/name}"
            readonly="${view/readonly}"
-           required="${never_set_as_required_backend_validation_takes_care_of_that|nothing}"
+           required="${python: view.required and 'required' or None}"
            size="${view/size}"
            type="${view/type|string:text}"
            value="${view/value}"

--- a/src/osha/oira/ploneintranet/z3cform/templates/conditional_textarea_input.pt
+++ b/src/osha/oira/ploneintranet/z3cform/templates/conditional_textarea_input.pt
@@ -31,7 +31,7 @@
               disabled="${view/disabled}"
               name="${view/name}"
               readonly="${view/readonly}"
-              required="${never_set_as_required_backend_validation_takes_care_of_that|nothing}"
+              required="${python: view.required and 'required' or None}"
               rows="${view/rows}"
     >${view/value}</textarea>
     <metal:help use-macro="view/@@quaive_form_macros/help_tooltip" />


### PR DESCRIPTION
pat-depends disables hidden input fields in action-mode "enable" and "both" since Patternslib 9.10.

Ref: scrum-2615.

This needs:
https://github.com/quaive/quaive.resources.ploneintranet/pull/110
https://github.com/quaive/quaive.resources.ploneintranet/pull/114
https://github.com/euphorie/NuPlone/pull/53
https://github.com/euphorie/osha.oira/pull/295