### PR TITLE
Mailing lists: Sort language-specific entries

### DIFF
--- a/src/osha/oira/client/browser/client.py
+++ b/src/osha/oira/client/browser/client.py
@@ -139,7 +139,7 @@ class MailingListsJson(BaseJson):
             self._get_entry(
                 "-".join((brain.getId, language)), f"{brain.Title} ({language})"
             )
-            for language in languages
+            for language in sorted(languages)
         ]
 
     def filter_permission(self, brains, query, user):

--- a/src/osha/oira/client/tests/test_mailing_lists.py
+++ b/src/osha/oira/client/tests/test_mailing_lists.py
@@ -111,15 +111,15 @@ class TestMailingLists(EuphorieIntegrationTestCase):
         self.assertEqual(
             results[0],
             {
-                "id": "nl-nl|VGhlIE5ldGhlcmxhbmRzIChubCk=",
-                "text": "The Netherlands (nl) [0 subscribers]",
+                "id": "nl-fr|VGhlIE5ldGhlcmxhbmRzIChmcik=",
+                "text": "The Netherlands (fr) [0 subscribers]",
             },
         )
         self.assertEqual(
             results[1],
             {
-                "id": "nl-fr|VGhlIE5ldGhlcmxhbmRzIChmcik=",
-                "text": "The Netherlands (fr) [0 subscribers]",
+                "id": "nl-nl|VGhlIE5ldGhlcmxhbmRzIChubCk=",
+                "text": "The Netherlands (nl) [0 subscribers]",
             },
         )
 


### PR DESCRIPTION
Stable sorting is necessary to make batching work reliably.

Ref https://github.com/syslabcom/scrum/issues/2316