### PR TITLE
Mailing Lists: Do catalog search in admin section

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,6 +27,10 @@ Changelog
   (`#2636 <https://github.com/syslabcom/scrum/issues/2636>`_)
   [reinhardt]
 
+- Mailing Lists fixes
+  (`#3124 <https://github.com/syslabcom/scrum/issues/3124>`_)
+  [reinhardt]
+
 
 10.1.0 (2025-01-15)
 -------------------

--- a/src/osha/oira/client/tests/test_mailing_lists.py
+++ b/src/osha/oira/client/tests/test_mailing_lists.py
@@ -1,19 +1,21 @@
+from euphorie.client.browser import publish
 from euphorie.client.interfaces import IClientSkinLayer
 from euphorie.client.model import Account
 from euphorie.client.model import SurveySession
 from euphorie.client.tests.utils import addSurvey
+from euphorie.content.browser import upload
 from euphorie.content.tests.utils import BASIC_SURVEY
-from euphorie.testing import EuphorieIntegrationTestCase
 from osha.oira.client.browser.client import GroupToAddresses
 from osha.oira.client.browser.client import MailingListsJson
 from osha.oira.client.model import NewsletterSubscription
+from osha.oira.testing import OiRAIntegrationTestCase
 from plone import api
 from unittest import mock
 from z3c.saconfig import Session
 from zope.interface import alsoProvides
 
 
-class TestMailingLists(EuphorieIntegrationTestCase):
+class TestMailingLists(OiRAIntegrationTestCase):
     def setUp(self):
         super().setUp()
         survey = """<sector xmlns="http://xml.simplon.biz/euphorie/survey/1.0">
@@ -23,10 +25,33 @@ class TestMailingLists(EuphorieIntegrationTestCase):
                         <language>fr</language>
                         </survey>
                     </sector>"""
+        survey2 = """<sector xmlns="http://xml.simplon.biz/euphorie/survey/1.0">
+                      <title>Another Test</title>
+                      <survey>
+                        <title>Audio Production</title>
+                        <language>fr</language>
+                        </survey>
+                    </sector>"""
 
         with api.env.adopt_user("admin"):
             addSurvey(self.portal, BASIC_SURVEY)
             addSurvey(self.portal, survey)
+
+            importer = upload.SectorImporter(self.portal.sectors.de)
+            sector = importer(survey2, None, None, None, "test import")
+            survey = sector.values()[0]["test-import"]
+            publisher = publish.PublishSurvey(survey, self.portal.REQUEST)
+            publisher.publish()
+
+            with mock.patch.object(self.portal.acl_users.euphorie, "REQUEST"):
+                self.user = api.user.create(
+                    username="ignaz", email="ignaz@example.org", password="Secret123!"
+                )
+            api.user.grant_roles(
+                username="ignaz", obj=self.portal.sectors.nl, roles=["CountryManager"]
+            )
+
+            self.portal.portal_catalog.manage_reindexIndex("managerRolesAndUsers")
 
     def test_mailing_lists(self):
         request = self.request.clone()
@@ -67,7 +92,7 @@ class TestMailingLists(EuphorieIntegrationTestCase):
 
     def test_mailing_lists_batching(self):
         request = self.request.clone()
-        request.form = {"user_id": "admin", "page_limit": "2"}
+        request.form = {"user_id": "ignaz", "page_limit": "2"}
         with mock.patch.object(
             MailingListsJson,
             "addresses_view",
@@ -76,29 +101,23 @@ class TestMailingLists(EuphorieIntegrationTestCase):
             view = MailingListsJson(context=self.portal.client, request=request)
             results = view.results
 
-        # Result = 3, because the "general" mailing list is always added
-        # on page one for admin users.
-        self.assertEqual(len(results), 3)
+        self.assertEqual(len(results), 2)
         self.assertEqual(
             results[0],
-            {"id": "general|QWxsIHVzZXJz", "text": "All users [0 subscribers]"},
-        )
-        self.assertEqual(
-            results[1],
             {
                 "id": "nl/ict/software-development|U29mdHdhcmUgZGV2ZWxvcG1lbnQ=",
                 "text": "Software development (nl/ict/software-development) [0 subscribers]",  # noqa: E501
             },
         )
         self.assertEqual(
-            results[2],
+            results[1],
             {
                 "id": "nl/test/software-development|U29mdHdhcmUgZGV2ZWxvcG1lbnQ=",
                 "text": "Software development (nl/test/software-development) [0 subscribers]",  # noqa: E501
             },
         )
 
-        request.form = {"user_id": "admin", "page_limit": "2", "page": "2"}
+        request.form = {"user_id": "ignaz", "page_limit": "2", "page": "2"}
         with mock.patch.object(
             MailingListsJson,
             "addresses_view",

--- a/src/osha/oira/profiles/default/workflows.xml
+++ b/src/osha/oira/profiles/default/workflows.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object name="portal_workflow">
+  <bindings>
+    <type type_id="euphorie.country">
+      <bound-workflow workflow_id="one_state_workflow" />
+    </type>
+  </bindings>
+</object>

--- a/src/osha/oira/testing.py
+++ b/src/osha/oira/testing.py
@@ -22,6 +22,8 @@ class OiRAFixture(EuphorieFixture):
     def setUpPloneSite(self, portal):
         super().setUpPloneSite(portal)
         self.applyProfile(portal, "osha.oira:default")
+        if "pasldap" in portal.acl_users:
+            portal.acl_users.manage_delObjects(["pasldap"])
 
 
 OIRA_FIXTURE = OiRAFixture()

--- a/src/osha/oira/upgrade/v1/20250131160406_set_country_workflow/upgrade.py
+++ b/src/osha/oira/upgrade/v1/20250131160406_set_country_workflow/upgrade.py
@@ -1,0 +1,12 @@
+from ftw.upgrade import UpgradeStep
+from plone import api
+
+
+class SetCountryWorkflow(UpgradeStep):
+    """Set country workflow."""
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        for brain in api.content.find(portal_type="euphorie.country"):
+            obj = brain.getObject()
+            obj.reindexObject(idxs=["review_state"])

--- a/src/osha/oira/upgrade/v1/20250131160406_set_country_workflow/workflows.xml
+++ b/src/osha/oira/upgrade/v1/20250131160406_set_country_workflow/workflows.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object name="portal_workflow">
+  <bindings>
+    <type type_id="euphorie.country">
+      <bound-workflow workflow_id="one_state_workflow" />
+    </type>
+  </bindings>
+</object>


### PR DESCRIPTION
When first getting a catalog batch of client objects and then filtering out some objects, we can end up with fewer items. This makes the autosuggest think it is the last batch, and it stops requesting more.

We add a one state workflow to countries so that a query for `published` also returns countries.

Ref https://github.com/syslabcom/scrum/issues/3124