### PR TITLE
Remove the polyfills-loader.js script.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,9 @@ Changelog
 11.0.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Remove the polyfills-loader.js script. Loading the few polyfills we need in
+  Patternslib is done by Patternslib itself.
+  [thet]
 
 
 11.0.2 (2025-04-01)

--- a/src/osha/oira/client/browser/templates/certificate-print.pt
+++ b/src/osha/oira/client/browser/templates/certificate-print.pt
@@ -28,9 +28,6 @@
           type="text/css"
     />
     <script>window.__patternslib_public_path__ = "${webhelpers/client_url}/${webhelpers/script_path}/";</script>
-    <script src="${webhelpers/client_url}/${webhelpers/script_path}/polyfills-loader.js"
-            type="text/javascript"
-    ></script>
     <script src="${webhelpers/js_url}"
             type="text/javascript"
     ></script>


### PR DESCRIPTION
Loading the few polyfills we need in Patternslib is done by Patternslib itself.