### PR TITLE
Load dimensions from server, reload after navigation change

### DIFF
--- a/matomo/matomo-tracking.html
+++ b/matomo/matomo-tracking.html
@@ -1,5 +1,7 @@
 <!-- Tracking -->
 <script type="text/javascript">
+var _paq = _paq || [];
+
 async function() {
     const hostname_production = "oira.osha.europa.eu";
     const hostname_staging = "test-oira.osha.europa.eu";
@@ -17,8 +19,6 @@ async function() {
     const site_id = mode_production ? "11" : "9";
 
     let previous_url = location.href;
-
-    const _paq = _paq || [];
 
     /**
      * Initialize download buttons tracking without the session id.

--- a/matomo/matomo-tracking.html
+++ b/matomo/matomo-tracking.html
@@ -12,9 +12,9 @@ var _paq = _paq || [];
     const tracking_endpoint_url = (
         mode_development ?
             "http://localhost:8080/Plone/piwikmock.php" :
-            "https://piwik.osha.europa.eu/piwik/piwik.php"
+            "https://piwik.osha.europa.eu/piwik/matomo.php"
     );
-    const tracking_script_url = "https://piwik.osha.europa.eu/piwik/piwik.js";
+    const tracking_script_url = "https://piwik.osha.europa.eu/piwik/matomo.js";
     const tracking_domain = (mode_production ? "*.oira.osha.europa.eu" : "*.test-oira.osha.europa.eu") + "/oira-tools/";
     const site_id = mode_production ? "9" : "11";
 
@@ -177,7 +177,6 @@ var _paq = _paq || [];
         // Create tracking script element
         const tracking_script = document.createElement("script");
         tracking_script.type="text/javascript";
-        tracking_script.defer=true;
         tracking_script.async=true;
         tracking_script.src= tracking_script_url;
 

--- a/matomo/matomo-tracking.html
+++ b/matomo/matomo-tracking.html
@@ -1,0 +1,71 @@
+<!-- Piwik -->
+<script type="text/javascript">
+    var _paq = _paq || [];
+
+    /**
+     * Initialize download buttons tracking without the session id.
+     * This uses delegated event handlers which also allows to track links
+     * injected dynamically by JavaScript after this script was invoked.
+    */
+    function initialize_download_buttons() {
+        const download_button_selector = "a.pat-button.download";
+
+        // Delegated event handler to disable automatic download link tracking
+        // for the report download links.
+        // NOTE: This needs Matomo version 5+
+        document.addEventListener("mousedown", function(event) {
+            const el = event.target.closest(download_button_selector);
+            if (el) {
+                el.setAttribute('data-matomo-ignore', 'true');
+            }
+        }, { capture: true });
+
+        // Manually trigger tracking with a cleaned-up URL which does not include the session.
+        document.addEventListener("click", function(event) {
+            const el = event.target.closest(download_button_selector);
+            if (el) {
+                // Remove the session ID from the URL
+                const download_url = el.href.replace(/\+\+session\+\+.*\//, "");
+                // Trigger tracking.
+                _paq.push(["trackEvent", "Download", "manual", download_url]);
+            }
+        });
+    }
+
+    // Initialize download buttons tracking
+    initialize_download_buttons();
+
+    (function() {
+        // Custom variables
+        _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+        _paq.push(["setDomains", ["*.osha.europa.eu","*.osha.europa.eu"]]);
+        _paq.push(["trackPageView"]);
+        _paq.push(["enableLinkTracking"]);
+
+        var country = document.getElementById('country_name').innerHTML;
+        var sector = document.getElementById('sector_name').innerHTML;
+        var tool = document.getElementById('tool_name').innerHTML;
+        var language =  document.getElementById('language_code').innerHTML;
+
+        _paq.push(["setCustomVariable", 1, "Activity", "3.1. Online interactive Risk Assessment (OiRA) tool", "visit"]);
+        _paq.push(["setCustomVariable", 2, "Country", country, "visit"]);
+        _paq.push(["setCustomVariable", 3, "Sector", sector, "visit"]);
+        _paq.push(["setCustomVariable", 4, "Tool", tool, "visit"]);
+
+        _paq.push(['setCustomDimension', 1, "-3.1. Online interactive Risk Assessment (OiRA) tool"]);
+        _paq.push(['setCustomDimension', 2, country]);
+        _paq.push(['setCustomDimension', 3, sector]);
+        _paq.push(['setCustomDimension', 4, tool]);
+        _paq.push(['setCustomDimension', 5, language]);   
+
+        // Main Matomo variables
+        var u=(("https:" == document.location.protocol) ? "https" : "http") + "://piwik.osha.europa.eu/piwik/";
+        _paq.push(["setTrackerUrl", u+"piwik.php"]);
+        _paq.push(["setSiteId", "11"]);
+
+        // Add the piwik.js script to the page
+        var d=document, g=d.createElement("script"), s=d.getElementsByTagName("script")[0]; g.type="text/javascript";
+        g.defer=true; g.async=true; g.src=u+"piwik.js"; s.parentNode.insertBefore(g,s);
+    })();
+</script>
+<!-- End Piwik Code -->

--- a/matomo/matomo-tracking.html
+++ b/matomo/matomo-tracking.html
@@ -16,7 +16,7 @@ var _paq = _paq || [];
     );
     const tracking_script_url = "https://piwik.osha.europa.eu/piwik/piwik.js";
     const tracking_domain = (mode_production ? "*.oira.osha.europa.eu" : "*.test-oira.osha.europa.eu") + "/oira-tools/";
-    const site_id = mode_production ? "11" : "9";
+    const site_id = mode_production ? "9" : "11";
 
     const download_url_selectors = [
         "a.pat-button.download",

--- a/matomo/matomo-tracking.html
+++ b/matomo/matomo-tracking.html
@@ -18,6 +18,22 @@ var _paq = _paq || [];
     const tracking_domain = (mode_production ? "*.oira.osha.europa.eu" : "*.test-oira.osha.europa.eu") + "/oira-tools/";
     const site_id = mode_production ? "11" : "9";
 
+    const download_url_selectors = [
+        "a.pat-button.download",
+        "[href='*@@pdf']",
+        "[href='*@@timeline']",
+        "[href='*.docx']",
+        "[href='*.xlsx']",
+        "[href='*.pptx']",
+        "[href='*.pdf']",
+        "[href='*.gif']",
+        "[href='*.jpeg']",
+        "[href='*.jpg']",
+        "[href='*.png']",
+        "[href='*.zip']",
+    ].join(", ");
+    const outbound_url_selector = `a[href^="${window.location.origin}"]:not([href^="#"]):not([href^="."])`;
+
     console.debug("mode_production", mode_production);
     console.debug("mode_staging", mode_staging);
     console.debug("mode_development", mode_development);
@@ -32,16 +48,35 @@ var _paq = _paq || [];
      * This uses delegated event handlers which also allows to track links
      * injected dynamically by JavaScript after this script was invoked.
     */
-    function initialize_download_buttons() {
+    function initialize_link_tracking() {
+        // We do our own link tracking.
+        //_paq.push(["enableLinkTracking"]);
+
         const download_button_selector = "a.pat-button.download";
         // Delegated event handler to set the custom url befor automatic download tracking.
-        document.addEventListener("mousedown", function(event) {
-            const el = event.target.closest(download_button_selector);
-            if (el) {
-                const download_url = el.href.replace(/\+\+session\+\+.*\//, "");
-                // Set the custom URL before automatic tracking
-                _paq.push(['setCustomUrl', download_url]);
+        document.addEventListener("click", function(event) {
+            const el = event.target.closest("a");
+            if (!el) {
+                // No link was clicked
+                return;
             }
+
+            let link_type;
+            if (el.matches(download_url_selectors)) {
+                // Download URL
+                link_type = "download";
+            } else if (el.matches(outbound_url_selector)) {
+                // Outbound URL
+                link_type = "link";
+            } else {
+                // Not a tracked link
+                return;
+            }
+
+            const tracked_url = el.href.replace(/\+\+session\+\+.*\//, "");
+            // Trigger tracking.
+            _paq.push(["trackLink", tracked_url, link_type]);
+
         }, { capture: true });
     }
 
@@ -123,7 +158,6 @@ var _paq = _paq || [];
 
     function base_tracking_initialization() {
         // Main Matomo variables
-        _paq.push(["enableLinkTracking"]);
         _paq.push(["setDomains", tracking_domain]);
         _paq.push(["setTrackerUrl", tracking_endpoint_url]);
         _paq.push(["setSiteId", site_id]);
@@ -141,13 +175,14 @@ var _paq = _paq || [];
     }
 
     // Initialize download buttons tracking
-    initialize_download_buttons();
+    initialize_link_tracking();
     // Compile tracking variables
     await compile_tracking_variables();
     // Initialize base tracking
     base_tracking_initialization();
 
     document.addEventListener("patterns-injected-delayed", function() {
+        // Track page injections with history changes.
         if (previous_url !== location.href) {
             // Only track if the URL has changed
             previous_url = location.href;

--- a/matomo/matomo-tracking.html
+++ b/matomo/matomo-tracking.html
@@ -16,6 +16,8 @@ async function() {
     const tracking_domain = (mode_production ? "*.oira.osha.europa.eu" : "*.test-oira.osha.europa.eu") + "/oira-tools/";
     const site_id = mode_production ? "11" : "9";
 
+    let previous_url = location.href;
+
     const _paq = _paq || [];
 
     /**
@@ -79,6 +81,9 @@ async function() {
         // Custom variables
         _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
 
+        // Set the URL to be tracked
+        _paq.push(["setCustomUrl", location.href]);
+
         /* retrieve custom variable content */
         const country = tracking_dimensions['country_name'];
         const sector = tracking_dimensions['sector_name'];
@@ -125,6 +130,17 @@ async function() {
     await compile_tracking_variables();
     // Initialize base tracking
     base_tracking_initialization();
+
+    document.addEventListener("patterns-injected-delayed", function() {
+        if (previous_url !== location.href) {
+            // Only track if the URL has changed
+            previous_url = location.href;
+            // reload tracking variables after navigating without a page reload.
+            compile_tracking_variables();
+        }
+    });
+
+
 }();
 </script>
 <!-- End tracking code -->

--- a/matomo/matomo-tracking.html
+++ b/matomo/matomo-tracking.html
@@ -62,8 +62,8 @@ var _paq = _paq || [];
         // We do our own link tracking.
         //_paq.push(["enableLinkTracking"]);
 
-        const download_button_selector = "a.pat-button.download";
-        // Delegated event handler to set the custom url befor automatic download tracking.
+        // Delegated event handler - this also tracks content which is injected
+        // after the initial page load.
         document.addEventListener("click", function(event) {
             const el = event.target.closest("a");
             if (!el) {

--- a/matomo/matomo-tracking.html
+++ b/matomo/matomo-tracking.html
@@ -18,6 +18,13 @@ var _paq = _paq || [];
     const tracking_domain = (mode_production ? "*.oira.osha.europa.eu" : "*.test-oira.osha.europa.eu") + "/oira-tools/";
     const site_id = mode_production ? "11" : "9";
 
+    console.debug("mode_production", mode_production);
+    console.debug("mode_staging", mode_staging);
+    console.debug("mode_development", mode_development);
+    console.debug("tracking_endpoint_url", tracking_endpoint_url);
+    console.debug("tracking_domain", tracking_domain);
+    console.debug("site_id", site_id);
+
     let previous_url = location.href;
 
     /**

--- a/matomo/matomo-tracking.html
+++ b/matomo/matomo-tracking.html
@@ -1,6 +1,22 @@
-<!-- Piwik -->
+<!-- Tracking -->
 <script type="text/javascript">
-    var _paq = _paq || [];
+async function() {
+    const hostname_production = "oira.osha.europa.eu";
+    const hostname_staging = "test-oira.osha.europa.eu";
+    const hostname_development = "localhost";
+    const mode_production = location.hostname === hostname_production;
+    const mode_staging = location.hostname === hostname_staging;
+    const mode_development = location.hostname === hostname_development;
+    const tracking_endpoint_url = (
+        mode_development ?
+            "http://localhost:8080/Plone/piwikmock.php" :
+            "https://piwik.osha.europa.eu/piwik/piwik.php"
+    );
+    const tacking_script_url = "https://piwik.osha.europa.eu/piwik/piwik.js";
+    const tracking_domain = (mode_production ? "*.oira.osha.europa.eu" : "*.test-oira.osha.europa.eu") + "/oira-tools/";
+    const site_id = mode_production ? "11" : "9";
+
+    const _paq = _paq || [];
 
     /**
      * Initialize download buttons tracking without the session id.
@@ -20,20 +36,54 @@
         }, { capture: true });
     }
 
-    // Initialize download buttons tracking
-    initialize_download_buttons();
+    async function load_tracking_dimensions() {
+        try {
+            const url_elems = window.location.href.split("?");
+            const urlParts = url_elems[0].split("/");
+            if (urlParts[urlParts.length - 1] === "") {
+                urlParts.pop();  // Remove trailing slash if present
+            }
+            urlParts[urlParts.length - 1] = "@@piwikvars.json";
+            let vars_url = urlParts.join("/");
+            if (url_elems.length >1) {
+                vars_url = vars_url + '?' + url_elems[1];
+            }
+            console.log(vars_url);
 
-    (function() {
+            const response = await fetch(vars_url, {
+                headers: { "Accept": "application/json" },
+            });
+            if (!response.ok) {
+                throw new Error("HTTP " + response.status);
+            }
+
+            const data = await response.json();
+            console.log("📌 Loaded Piwik Variables:", data);
+            return data;
+        } catch (error) {
+            console.error("❌ Error loading Piwik variables:", error);
+            return null;
+        }
+    }
+
+    async function compile_tracking_variables() {
+        // Wait for JSON data before proceeding
+        const tracking_dimensions = await load_tracking_dimensions();
+
+        if (!tracking_dimensions) {
+            console.error("❌ No Piwik data loaded, skipping tracking.");
+            return;
+        }
+        console.log("✅ Matomo tracking initialized with custom variables.");
+
         // Custom variables
         _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-        _paq.push(["setDomains", ["*.osha.europa.eu","*.osha.europa.eu"]]);
-        _paq.push(["trackPageView"]);
-        _paq.push(["enableLinkTracking"]);
 
-        var country = document.getElementById('country_name').innerHTML;
-        var sector = document.getElementById('sector_name').innerHTML;
-        var tool = document.getElementById('tool_name').innerHTML;
-        var language =  document.getElementById('language_code').innerHTML;
+        /* retrieve custom variable content */
+        const country = tracking_dimensions['country_name'];
+        const sector = tracking_dimensions['sector_name'];
+        const tool = tracking_dimensions['tool_name'];
+        const language = tracking_dimensions['language_code'];
 
         _paq.push(["setCustomVariable", 1, "Activity", "3.1. Online interactive Risk Assessment (OiRA) tool", "visit"]);
         _paq.push(["setCustomVariable", 2, "Country", country, "visit"]);
@@ -44,16 +94,37 @@
         _paq.push(['setCustomDimension', 2, country]);
         _paq.push(['setCustomDimension', 3, sector]);
         _paq.push(['setCustomDimension', 4, tool]);
-        _paq.push(['setCustomDimension', 5, language]);   
+        _paq.push(['setCustomDimension', 5, language]);
 
+        // Queue or invoke (if tracking script is already loaded) the tracking request
+        _paq.push(["trackPageView"]);
+    }
+
+    function base_tracking_initialization() {
         // Main Matomo variables
-        var u=(("https:" == document.location.protocol) ? "https" : "http") + "://piwik.osha.europa.eu/piwik/";
-        _paq.push(["setTrackerUrl", u+"piwik.php"]);
-        _paq.push(["setSiteId", "11"]);
+        _paq.push(["enableLinkTracking"]);
+        _paq.push(["setDomains", tracking_domain]);
+        _paq.push(["setTrackerUrl", tracking_endpoint_url]);
+        _paq.push(["setSiteId", site_id]);
 
-        // Add the piwik.js script to the page
-        var d=document, g=d.createElement("script"), s=d.getElementsByTagName("script")[0]; g.type="text/javascript";
-        g.defer=true; g.async=true; g.src=u+"piwik.js"; s.parentNode.insertBefore(g,s);
-    })();
+        // Create tracking script element
+        const tracking_script = document.createElement("script");
+        tracking_script.type="text/javascript";
+        tracking_script.defer=true;
+        tracking_script.async=true;
+        tracking_script.src= tracking_script_url;
+
+        // Add the tracking script to the page
+        const sibling = document.getElementsByTagName("script")[0];
+        sibling.parentNode.insertBefore(tracking_script, sibling);
+    }
+
+    // Initialize download buttons tracking
+    initialize_download_buttons();
+    // Compile tracking variables
+    await compile_tracking_variables();
+    // Initialize base tracking
+    base_tracking_initialization();
+}();
 </script>
-<!-- End Piwik Code -->
+<!-- End tracking code -->

--- a/matomo/matomo-tracking.html
+++ b/matomo/matomo-tracking.html
@@ -2,7 +2,7 @@
 <script type="text/javascript">
 var _paq = _paq || [];
 
-async function() {
+(async function () {
     const hostname_production = "oira.osha.europa.eu";
     const hostname_staging = "test-oira.osha.europa.eu";
     const hostname_development = "localhost";
@@ -14,7 +14,7 @@ async function() {
             "http://localhost:8080/Plone/piwikmock.php" :
             "https://piwik.osha.europa.eu/piwik/piwik.php"
     );
-    const tacking_script_url = "https://piwik.osha.europa.eu/piwik/piwik.js";
+    const tracking_script_url = "https://piwik.osha.europa.eu/piwik/piwik.js";
     const tracking_domain = (mode_production ? "*.oira.osha.europa.eu" : "*.test-oira.osha.europa.eu") + "/oira-tools/";
     const site_id = mode_production ? "11" : "9";
 
@@ -141,6 +141,6 @@ async function() {
     });
 
 
-}();
+})();
 </script>
 <!-- End tracking code -->

--- a/matomo/matomo-tracking.html
+++ b/matomo/matomo-tracking.html
@@ -43,6 +43,16 @@ var _paq = _paq || [];
 
     let previous_url = location.href;
 
+
+    /**
+     * Clean a URL by removing the session id.
+     */
+    function clean_url(url) {
+        // Remove the session id from the URL
+        const tracked_url = url.replace(/\+\+session\+\+.*\//, "");
+        return tracked_url;
+    }
+
     /**
      * Initialize download buttons tracking without the session id.
      * This uses delegated event handlers which also allows to track links
@@ -73,9 +83,8 @@ var _paq = _paq || [];
                 return;
             }
 
-            const tracked_url = el.href.replace(/\+\+session\+\+.*\//, "");
             // Trigger tracking.
-            _paq.push(["trackLink", tracked_url, link_type]);
+            _paq.push(["trackLink", clean_url(el.href), link_type]);
 
         }, { capture: true });
     }
@@ -133,7 +142,8 @@ var _paq = _paq || [];
         _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
 
         // Set the URL to be tracked
-        _paq.push(["setCustomUrl", location.href]);
+        _paq.push(["setCustomUrl", clean_url(window.location.href)]);
+        _paq.push(["setReferrerUrl", clean_url(document.referrer)]);
 
         /* retrieve custom variable content */
         const country = tracking_dimensions.country_name;

--- a/matomo/matomo-tracking.html
+++ b/matomo/matomo-tracking.html
@@ -9,27 +9,15 @@
     */
     function initialize_download_buttons() {
         const download_button_selector = "a.pat-button.download";
-
-        // Delegated event handler to disable automatic download link tracking
-        // for the report download links.
-        // NOTE: This needs Matomo version 5+
+        // Delegated event handler to set the custom url befor automatic download tracking.
         document.addEventListener("mousedown", function(event) {
             const el = event.target.closest(download_button_selector);
             if (el) {
-                el.setAttribute('data-matomo-ignore', 'true');
+                const download_url = el.href.replace(/\+\+session\+\+.*\//, "");
+                // Set the custom URL before automatic tracking
+                _paq.push(['setCustomUrl', download_url]);
             }
         }, { capture: true });
-
-        // Manually trigger tracking with a cleaned-up URL which does not include the session.
-        document.addEventListener("click", function(event) {
-            const el = event.target.closest(download_button_selector);
-            if (el) {
-                // Remove the session ID from the URL
-                const download_url = el.href.replace(/\+\+session\+\+.*\//, "");
-                // Trigger tracking.
-                _paq.push(["trackEvent", "Download", "manual", download_url]);
-            }
-        });
     }
 
     // Initialize download buttons tracking

--- a/matomo/matomo-tracking.html
+++ b/matomo/matomo-tracking.html
@@ -34,12 +34,12 @@ var _paq = _paq || [];
     ].join(", ");
     const outbound_url_selector = `a[href^="${window.location.origin}"]:not([href^="#"]):not([href^="."])`;
 
-    console.debug("mode_production", mode_production);
-    console.debug("mode_staging", mode_staging);
-    console.debug("mode_development", mode_development);
-    console.debug("tracking_endpoint_url", tracking_endpoint_url);
-    console.debug("tracking_domain", tracking_domain);
-    console.debug("site_id", site_id);
+    console.debug("Matomo: mode_production", mode_production);
+    console.debug("Matomo: mode_staging", mode_staging);
+    console.debug("Matomo: mode_development", mode_development);
+    console.debug("Matomo: tracking_endpoint_url", tracking_endpoint_url);
+    console.debug("Matomo: tracking_domain", tracking_domain);
+    console.debug("Matomo: site_id", site_id);
 
     let previous_url = location.href;
 
@@ -101,7 +101,6 @@ var _paq = _paq || [];
             if (url_elems.length >1) {
                 vars_url = vars_url + '?' + url_elems[1];
             }
-            console.log(vars_url);
 
             const response = await fetch(vars_url, {
                 headers: { "Accept": "application/json" },
@@ -111,22 +110,25 @@ var _paq = _paq || [];
             }
 
             const data = await response.json();
-            console.log("📌 Loaded Piwik Variables:", data);
+            console.debug("Matomo: 📌 Loaded Piwik Variables:", data);
             return data;
         } catch (error) {
-            console.error("❌ Error loading Piwik variables:", error);
+            console.error("Matomo: ❌ Error loading Piwik variables:", error);
             return null;
         }
     }
 
     async function compile_tracking_variables() {
+        console.debug("Matomo: Tracking triggered.");
+
+
         // Wait for JSON data before proceeding
         // TODO: ENABLE for scrum-3351
         //const tracking_dimensions = await load_tracking_dimensions();
         const tracking_dimensions = {};
 
         if (!tracking_dimensions) {
-            console.error("❌ No Piwik data loaded, skipping tracking.");
+            console.error("Matomo: ❌ No Piwik data loaded, skipping tracking.");
 
             // Fall back to tracking dimensions from the template.
             // TODO: this code can probably be removed when scrum-3351 is rolled-out.
@@ -136,7 +138,7 @@ var _paq = _paq || [];
             tracking_dimensions.language_code = document.getElementById('language_code').innerHTML;
             //return;
         }
-        console.log("✅ Matomo tracking initialized with custom variables.");
+        console.debug("Matomo: ✅ tracking initialized with custom variables.");
 
         // Custom variables
         _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
@@ -194,6 +196,7 @@ var _paq = _paq || [];
     document.addEventListener("patterns-injected-delayed", function() {
         // Track page injections with history changes.
         if (previous_url !== location.href) {
+            console.debug("Matomo: pat-inject triggered tracking.");
             // Only track if the URL has changed
             previous_url = location.href;
             // reload tracking variables after navigating without a page reload.

--- a/matomo/matomo-tracking.html
+++ b/matomo/matomo-tracking.html
@@ -77,11 +77,20 @@ var _paq = _paq || [];
 
     async function compile_tracking_variables() {
         // Wait for JSON data before proceeding
-        const tracking_dimensions = await load_tracking_dimensions();
+        // TODO: ENABLE for scrum-3351
+        //const tracking_dimensions = await load_tracking_dimensions();
+        const tracking_dimensions = {};
 
         if (!tracking_dimensions) {
             console.error("❌ No Piwik data loaded, skipping tracking.");
-            return;
+
+            // Fall back to tracking dimensions from the template.
+            // TODO: this code can probably be removed when scrum-3351 is rolled-out.
+            tracking_dimensions.country_name = document.getElementById('country_name').innerHTML;
+            tracking_dimensions.sector_name = document.getElementById('sector_name').innerHTML;
+            tracking_dimensions.tool_name = document.getElementById('tool_name').innerHTML;
+            tracking_dimensions.language_code = document.getElementById('language_code').innerHTML;
+            //return;
         }
         console.log("✅ Matomo tracking initialized with custom variables.");
 
@@ -92,10 +101,10 @@ var _paq = _paq || [];
         _paq.push(["setCustomUrl", location.href]);
 
         /* retrieve custom variable content */
-        const country = tracking_dimensions['country_name'];
-        const sector = tracking_dimensions['sector_name'];
-        const tool = tracking_dimensions['tool_name'];
-        const language = tracking_dimensions['language_code'];
+        const country = tracking_dimensions.country_name;
+        const sector = tracking_dimensions.sector_name;
+        const tool = tracking_dimensions.tool_name;
+        const language = tracking_dimensions.language_code;
 
         _paq.push(["setCustomVariable", 1, "Activity", "3.1. Online interactive Risk Assessment (OiRA) tool", "visit"]);
         _paq.push(["setCustomVariable", 2, "Country", country, "visit"]);

--- a/news/3249.feature.rst
+++ b/news/3249.feature.rst
@@ -1,0 +1,19 @@
+OiRA Matomo: Add tracking snippet.
+
+This tracking snippet deactivates automatic link tracking for the report
+download buttons and tracks them manually.
+It removes the session id segment from the URL so that all downloads can be
+grouped together in Matomo and to not reveal DSGVO relevant data.
+
+Also:
+
+- Load dimensions from server.
+- Track after location change.
+- Implement custom link tracking.
+- Remove all session ids from any URLs, including current URL and referrer URL.
+
+Note: This does not add the tracking snippet to the portal automatically, but
+only provides the code to add it manually through-the-web.
+
+Ref: scrum-3351
+Ref: scrum-3249


### PR DESCRIPTION
Obsoletes: https://github.com/euphorie/osha.oira/pull/323

Related: https://github.com/euphorie/Euphorie/pull/838

NOTE: Fetching the custom dimension from an endpoint is yet disabled as this needs this PR to be finished: https://github.com/euphorie/Euphorie/pull/838

NOTE 2: the tracking reload mechanism is not using the navigate event polyfill from Patternslib, as this can also be done just with standard pat-inject events and comparing the new location.href to a previous one.

Ref: scrum-3351
Ref: scrum-3249


## PRs

https://github.com/euphorie/Euphorie/pull/838
https://github.com/euphorie/osha.oira/pull/324
