### PR TITLE
Add quaive-preview as wrapper around preview with a short template.

### DIFF
--- a/src/osha/oira/ploneintranet/configure.zcml
+++ b/src/osha/oira/ploneintranet/configure.zcml
@@ -166,6 +166,15 @@
       />
 
   <browser:page
+      name="quaive-preview"
+      for="euphorie.content.survey.ISurvey"
+      class="osha.oira.ploneintranet.quaive_publish.PreviewSurveyQuaiveForm"
+      template="templates/quaive-preview.pt"
+      permission="euphorie.client.PublishSurvey"
+      layer="plonetheme.nuplone.skin.interfaces.NuPloneSkin"
+      />
+
+  <browser:page
       name="quaive-create-euphorie.sector"
       for="*"
       class=".quaive_create.QuaiveCreateEuphorieSectorView"

--- a/src/osha/oira/ploneintranet/quaive_publish.py
+++ b/src/osha/oira/ploneintranet/quaive_publish.py
@@ -1,3 +1,4 @@
+from euphorie.client.browser.publish import PreviewSurvey
 from euphorie.client.browser.publish import PublishSurvey
 from osha.oira.ploneintranet.quaive_mixin import QuaiveEditFormMixin
 
@@ -51,4 +52,12 @@ class PublishSurveyQuaiveForm(QuaiveEditFormMixin, PublishSurvey):
     I think this should change the review state of the previous survey to
     'draft' though.  Or really of all sibling surveys (tool versions).
     But that may be too drastic.
+    """
+
+
+class PreviewSurveyQuaiveForm(QuaiveEditFormMixin, PreviewSurvey):
+    """Page for previewing a survey, designed to be embedded in Quaive.
+
+    The messages in the template are copied from
+    'euphorie.client.browser.templates.preview.pt'.
     """

--- a/src/osha/oira/ploneintranet/templates/quaive-preview.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-preview.pt
@@ -1,0 +1,13 @@
+<div id="quaive-content"
+     i18n:domain="euphorie"
+>
+  <p i18n:translate="intro_preview">Are you sure you want to create a preview of this OiRA Tool? You
+    can give the URL for the preview to others so they can test the OiRA Tool.
+    To access the preview a standard OiRA client login is required.
+  </p>
+
+  <p i18n:translate="help_preview_url">The preview will be available at
+    <strong i18n:name="url">${view/preview_url}</strong>.</p>
+
+  <span tal:replace="structure context/@@authenticator/authenticator"></span>
+</div>


### PR DESCRIPTION
Alternatively, we could let Quaive call the standard `@@preview`, but we would need a way to select the few lines from the html that we actually need. Selecting `#mainContent` mostly works, but it includes the title and buttons, and this needs updates to the css, because everything is too close together.

This is the OIRA part of https://github.com/syslabcom/scrum/issues/3487