### PR TITLE
@@survey-publication-count: include the "update" action in the count

### DIFF
--- a/news/343.feature
+++ b/news/343.feature
@@ -1,0 +1,1 @@
+@@survey-publication-count: when counting the number of times a Survey has been republished, include the "update" action along with "publish".

--- a/src/osha/oira/content/browser/survey_publication_count.py
+++ b/src/osha/oira/content/browser/survey_publication_count.py
@@ -18,7 +18,7 @@ def get_survey_details():
         review_history = wft.getInfoFor(survey, "review_history")
         count = 0
         for entry in review_history:
-            if entry["action"] == "publish":
+            if entry["action"] in ["publish", "update"]:
                 count += 1
         if count:
             split_path = brain.getPath().split("/")


### PR DESCRIPTION
when counting the number of times a Survey has been republished, include the "update" action along with "publish".

Refs: https://github.com/syslabcom/scrum/issues/3453