### PR TITLE
Register survey publication count views for the sector container

### DIFF
--- a/news/3488.fixed
+++ b/news/3488.fixed
@@ -1,0 +1,3 @@
+Register @@survey-publication-count @survey-publication-count.csv for the sector container, rather than the root, to make them easier to call from quaive.
+
+See: https://github.com/quaive/quaive.osha/pull/166

--- a/src/osha/oira/content/browser/configure.zcml
+++ b/src/osha/oira/content/browser/configure.zcml
@@ -266,7 +266,7 @@
 
   <browser:page
       name="survey-publication-count"
-      for="plone.app.layout.navigation.interfaces.INavigationRoot"
+      for="euphorie.content.sectorcontainer.ISectorContainer"
       class=".survey_publication_count.SurveyPublicationCount"
       template="templates/survey_publication_count.pt"
       permission="cmf.ManagePortal"
@@ -274,7 +274,7 @@
 
   <browser:page
       name="survey-publication-count.csv"
-      for="plone.app.layout.navigation.interfaces.INavigationRoot"
+      for="euphorie.content.sectorcontainer.ISectorContainer"
       class=".survey_publication_count.SurveyPublicationCountCSV"
       permission="cmf.ManagePortal"
       />

--- a/src/osha/oira/services/configure.zcml
+++ b/src/osha/oira/services/configure.zcml
@@ -51,7 +51,7 @@
   <plone:service
       method="GET"
       factory=".survey_publication_count.SurveyPublicationCountService"
-      for="plone.app.layout.navigation.interfaces.INavigationRoot"
+      for="euphorie.content.sectorcontainer.ISectorContainer"
       permission="cmf.ManagePortal"
       layer="osha.oira.interfaces.IOSHAContentSkinLayer"
       name="@survey-publication-count"


### PR DESCRIPTION
Register @@survey-publication-count @survey-publication-count.csv for the sector container, rather than the root, to make them easier to call from quaive.

Refs: https://github.com/quaive/quaive.osha/pull/166