### PR TITLE
Hack to fix the build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,8 @@ jobs:
         uses: pre-commit/action@v3.0.0
       - name: Test
         run: |
+          bin/pip install \
+              git+https://github.com/ale-rt/horse-with-no-namespace.git@main
           bin/coverage run bin/test -s osha.oira
           bin/coverage report --fail-under=38 -i
         env:

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "zope.app.publication",
         "zope.publisher",
     ],
-    python_requires=">=3.11,<3.13",
+    python_requires=">=3.11",
     extras_require={
         "tests": [
             "Euphorie [tests]",


### PR DESCRIPTION
This fixes the fact that we depend on `five.localsitemanager` through `pas.plugins.ldap`.

See:
- https://github.com/collective/pas.plugins.ldap/pull/134
- https://github.com/davisagli/horse-with-no-namespace/issues/2