### PR TITLE
Revert "fix-five-namespace"

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -32,12 +32,3 @@ zcml-additional =
 environment-vars =
     PREFER_Z3C_PT 1
     zope_i18n_compile_mo_files 1
-initialization =
-    import sys, os, types
-    if "five" not in sys.modules:
-        sys.modules["five"] = types.ModuleType("five")
-        sys.modules["five"].__path__ = []
-    for path in sys.path:
-        five_path = os.path.join(path, "five")
-        if os.path.isdir(five_path) and five_path not in sys.modules["five"].__path__:
-            sys.modules["five"].__path__.append(five_path)

--- a/devel.cfg
+++ b/devel.cfg
@@ -33,15 +33,7 @@ eggs =
     osha.oira [tests]
     Pillow
     psycopg2-binary
-initialization =
-    import sys, os, types
-    if "five" not in sys.modules:
-        sys.modules["five"] = types.ModuleType("five")
-        sys.modules["five"].__path__ = []
-    for path in sys.path:
-        five_path = os.path.join(path, "five")
-        if os.path.isdir(five_path) and five_path not in sys.modules["five"].__path__:
-            sys.modules["five"].__path__.append(five_path)
+
 
 [createcoverage]
 recipe = zc.recipe.egg


### PR DESCRIPTION
This reverts commit 3ef35c997653d8a86d919d009bca41d3ac22e7c5.

The fix is no longer needed as we released https://pypi.org/project/pas.plugins.ldap/1.8.4/