### PR TITLE
Add quaive-export-survey view.

### DIFF
--- a/news/3604.feature.rst
+++ b/news/3604.feature.rst
@@ -1,0 +1,1 @@
+Add quaive-export-survey view.

--- a/src/osha/oira/ploneintranet/configure.zcml
+++ b/src/osha/oira/ploneintranet/configure.zcml
@@ -272,6 +272,14 @@
       />
 
   <browser:page
+      name="quaive-export-survey"
+      for="euphorie.content.survey.ISurvey"
+      class=".quaive_export.ExportSurvey"
+      permission="zope2.View"
+      layer="osha.oira.interfaces.IOSHAContentSkinLayer"
+      />
+
+  <browser:page
       name="quaive-upload-survey"
       for="euphorie.content.sector.ISector"
       class=".quaive_upload.ImportSurvey"

--- a/src/osha/oira/ploneintranet/quaive_export.py
+++ b/src/osha/oira/ploneintranet/quaive_export.py
@@ -13,3 +13,5 @@ class ExportSurvey(EuphorieExportSurvey):
     template = ViewPageTemplateFile("templates/quaive-form.pt")
     label = _("Export OiRA Tool")
     description = ""
+    # We don't want to use pat-inject.  It interferes with the download.
+    use_injection = False

--- a/src/osha/oira/ploneintranet/quaive_export.py
+++ b/src/osha/oira/ploneintranet/quaive_export.py
@@ -1,0 +1,15 @@
+from euphorie.content.browser.export import ExportSurvey as EuphorieExportSurvey
+from osha.oira.ploneintranet.interfaces import IQuaiveForm
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zope.i18nmessageid import MessageFactory
+from zope.interface import implementer
+
+
+_ = MessageFactory("nuplone")
+
+
+@implementer(IQuaiveForm)
+class ExportSurvey(EuphorieExportSurvey):
+    template = ViewPageTemplateFile("templates/quaive-form.pt")
+    label = _("Export OiRA Tool")
+    description = ""

--- a/src/osha/oira/ploneintranet/templates/quaive-form.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-form.pt
@@ -14,11 +14,12 @@
   <metal:title fill-slot="title">${view/label}</metal:title>
   <metal:content fill-slot="content">
     <div id="quaive-content">
-      <form class="pat-form pat-inject"
+      <form class="pat-form ${python: 'pat-inject' if use_injection else ''}"
             id="${view/id}"
             action="${python: request.get('quaive_edit_url') or request.getURL()}"
             enctype="${view/enctype}"
             method="${view/method}"
+            tal:define="use_injection python: getattr(view, 'use_injection', True)"
             data-pat-inject="
               source: #application-body; target: #application-body; history: record; &amp;&amp;
               source: #sidebar-assessments; target: #sidebar-assessments

--- a/src/osha/oira/ploneintranet/z3cform/templates/submit_input.pt
+++ b/src/osha/oira/ploneintranet/z3cform/templates/submit_input.pt
@@ -1,7 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:define="
-        is_secondary python: 'secondary' in view.klass.split();
+        is_secondary python: 'secondary' in view.klass.split() or 'cancel' in view.name.split('.');
       "
       tal:omit-tag=""
 >


### PR DESCRIPTION
Refs https://github.com/syslabcom/scrum/issues/3604

I explicitly use the full page, not a panel, and do not use pat-inject.  Otherwise I could not get the download working on the Quaive side.  See second commit.

In https://github.com/euphorie/Euphorie/pull/889 I add a Cancel button in the base view, which is nice to have for this PR.