### PR TITLE
Fix layout after using panel-insert-from-tool in OiRA Creator.

### DIFF
--- a/news/4731.bugfix.rst
+++ b/news/4731.bugfix.rst
@@ -1,0 +1,1 @@
+Fix layout after using panel-insert-from-tool in OiRA Creator.  [maurits]

--- a/src/osha/oira/ploneintranet/templates/panel-insert-from-tool.pt
+++ b/src/osha/oira/ploneintranet/templates/panel-insert-from-tool.pt
@@ -34,6 +34,7 @@
                 method="${view/method}"
                 data-pat-inject="
                   source: #application-body::element;
+                  target: #application-body::element;
                 "
           >
 


### PR DESCRIPTION
Our `data-pat-inject` was missing a `target`.  This resulted in replacing too much, which lost the top blue header in Quaive.

Refs https://github.com/syslabcom/scrum/issues/4731