### PR TITLE
Support setting language preferences in the user settings.

### DIFF
--- a/news/3642.feature.rst
+++ b/news/3642.feature.rst
@@ -1,0 +1,2 @@
+Support setting language preferences in the user settings.
+Only when Euphorie supports it.  [maurits]

--- a/src/osha/oira/client/browser/settings.py
+++ b/src/osha/oira/client/browser/settings.py
@@ -15,6 +15,15 @@ class OSHAPreferences(Preferences):
     template = ViewPageTemplateFile("templates/preferences.pt")
 
     @property
+    def show_language_preferences(self):
+        # TODO Remove this method once we have a Euphorie release that has it.
+        try:
+            return super().show_language_preferences
+        except AttributeError:
+            # Our euphorie version does not support setting language preferences.
+            return False
+
+    @property
     @memoize
     def webhelpers(self):
         return api.content.get_view("webhelpers", self.context, self.request)
@@ -107,5 +116,8 @@ class OSHAPreferences(Preferences):
             else:
                 self.unsubscribe(tool_id)
         # TODO: Remove subscriptions for deleted assessments
+
+        if self.show_language_preferences:
+            self.update_language_preferences()
 
         self.request.__annotations__.pop("plone.memoize", None)

--- a/src/osha/oira/client/browser/templates/preferences.pt
+++ b/src/osha/oira/client/browser/templates/preferences.pt
@@ -59,6 +59,63 @@
             </fieldset>
 
             <fieldset class="form-panel pat-collapsible true section horizontal"
+                      id="patterns-label-language-prefs"
+                      data-pat-collapsible="store: local; scroll-selector: self; scroll-offset: 100px"
+                      tal:condition="view/show_language_preferences"
+            >
+              <h3 class="form-separation-header collapsible-open"
+                  i18n:translate="title_language_prefs"
+              >Language preferences
+              </h3>
+              <div class="panel-content">
+                <label>
+                  <tal:label i18n:translate="label_ui_language">UI language</tal:label>
+                  <dfn class="icon help help-icon pat-tooltip tooltip-active-click"
+                       data-pat-tooltip="class: info; trigger: click; source: content; position-list: tl"
+                       i18n:translate="help_ui_language"
+                  >The UI language is used for showing the user interface.
+                  Initially this is determined by the language preference of your browser.
+                  This does not influence the language of the contents, especially which surveys are shown.
+                  This preference resets after quitting your browser.
+                  </dfn>
+                  <select name="ui_language"
+                          tal:define="
+                            current view/get_current_ui_language;
+                          "
+                  >
+                    <option selected="${python:lang[0] == current}"
+                            value="${python:lang[0]}"
+                            tal:repeat="lang view/supported_languages"
+                    >${python:lang[1]}
+                    </option>
+                  </select>
+                </label>
+                <label tal:condition="view/show_content_language_preference">
+                  <tal:label i18n:translate="label_content_language">Content language</tal:label>
+                  <dfn class="icon help help-icon pat-tooltip tooltip-active-click"
+                       data-pat-tooltip="class: info; trigger: click; source: content; position-list: tl"
+                       i18n:translate="help_content_language"
+                  >The content language determines which surveys you see on the dashboard.
+                  Visiting a survey in a different language (via the Tools tab) will automatically update this setting.
+                  This preference resets after quitting your browser.
+                  </dfn>
+                  <select name="content_language"
+                          tal:define="
+                            current view/get_current_content_language;
+                          "
+                  >
+                    <option selected="${python:lang[0] == current}"
+                            value="${python:lang[0]}"
+                            tal:repeat="lang view/supported_languages"
+                    >${python:lang[1]}
+                    </option>
+                  </select>
+                </label>
+
+              </div>
+            </fieldset>
+
+            <fieldset class="form-panel pat-collapsible true section horizontal"
                       id="label-mailings"
                       data-pat-collapsible="store: local; scroll-selector: self; scroll-offset: 100px"
             >


### PR DESCRIPTION
This uses https://github.com/euphorie/Euphorie/pull/929 I take care to not let the Preferences page break when a Euphorie version is used that does not have this support.

Refs https://github.com/syslabcom/scrum/issues/3642