### PR TITLE
Manage ldap users: allow searching in source_users instead of pasldap.

### DIFF
--- a/news/+4df90f9b.internal.rst
+++ b/news/+4df90f9b.internal.rst
@@ -1,3 +1,3 @@
-Manage LDAP users (country/sector managers): first try `*query*`, but then fall back to the unchanged `query`.
-This makes local testing easier, allowing you to have a fake LDAP.
+Manage LDAP users (country/sector managers): only do `*query*` if we have a real LDAP plugin.
+Fall back to the unchanged `query`, allowing you to have a fake LDAP for local testing.
 [maurits]

--- a/news/+4df90f9b.internal.rst
+++ b/news/+4df90f9b.internal.rst
@@ -1,3 +1,3 @@
-Manage LDAP users (country/sector managers): search in ``source_users`` when ``pasldap`` is inactive.
-This make local testing easier.
+Manage LDAP users (country/sector managers): first try `*query*`, but then fall back to the unchanged `query`.
+This makes local testing easier, allowing you to have a fake LDAP.
 [maurits]

--- a/news/+4df90f9b.internal.rst
+++ b/news/+4df90f9b.internal.rst
@@ -1,4 +1,3 @@
-Manage LDAP users (country/sector managers): allow searching in ``source_users`` instead.
-Set environment variable `OIRA_SOURCE_USERS_INSTEAD_OF_LDAP=1` for this.
+Manage LDAP users (country/sector managers): search in ``source_users`` when ``pasldap`` is inactive.
 This make local testing easier.
 [maurits]

--- a/news/+4df90f9b.internal.rst
+++ b/news/+4df90f9b.internal.rst
@@ -1,0 +1,4 @@
+Manage LDAP users (country/sector managers): allow searching in ``source_users`` instead.
+Set environment variable `OIRA_SOURCE_USERS_INSTEAD_OF_LDAP=1` for this.
+This make local testing easier.
+[maurits]

--- a/src/osha/oira/content/browser/manage_ldap_users.py
+++ b/src/osha/oira/content/browser/manage_ldap_users.py
@@ -1,3 +1,4 @@
+from pas.plugins.ldap.plugin import LDAPPlugin
 from plone import api
 from plone.memoize.view import memoize
 from plone.memoize.view import memoize_contextless
@@ -57,11 +58,11 @@ class BaseManageLDAPUsersView(BrowserView):
         # For a real LDAP plugin we need '*query*', but in development or on
         # a test server you may have a fake LDAP plugin (same plugin as
         # source_users), and then you need 'query'.
-        results = (
-            self.ldap.enumerateUsers(f"*{query}*")
-            or self.ldap.enumerateUsers(query)
-            or ()
-        )
+        if isinstance(self.ldap, LDAPPlugin):
+            results = self.ldap.enumerateUsers(f"*{query}*")
+        else:
+            results = self.ldap.enumerateUsers(query)
+        results = results or ()
         return sorted(result["id"] for result in results)
 
     def grant_roles(self, user):

--- a/src/osha/oira/content/browser/manage_ldap_users.py
+++ b/src/osha/oira/content/browser/manage_ldap_users.py
@@ -4,9 +4,15 @@ from plone.memoize.view import memoize_contextless
 from Products.Five import BrowserView
 
 import logging
+import os
 
 
 logger = logging.getLogger(__name__)
+# When testing locally, you may not have LDAP configured.  You can switch to
+# searching for users in source_users by setting an environment variable.
+OIRA_SOURCE_USERS_INSTEAD_OF_LDAP = int(
+    os.getenv("OIRA_SOURCE_USERS_INSTEAD_OF_LDAP", 0)
+)
 
 
 class BaseManageLDAPUsersView(BrowserView):
@@ -54,8 +60,13 @@ class BaseManageLDAPUsersView(BrowserView):
     def enumerateUsersIds(self, query=""):
         if not query:
             return []
-        query = "*%s*" % query
-        results = self.ldap.enumerateUsers(query) or ()
+        if OIRA_SOURCE_USERS_INSTEAD_OF_LDAP:
+            logger.warning("Querying source users instead of LDAP for %s", query)
+            au = api.portal.get_tool("acl_users")
+            results = au.source_users.enumerateUsers(query) or ()
+        else:
+            query = "*%s*" % query
+            results = self.ldap.enumerateUsers(query) or ()
         return sorted(result["id"] for result in results)
 
     def grant_roles(self, user):

--- a/src/osha/oira/content/browser/manage_ldap_users.py
+++ b/src/osha/oira/content/browser/manage_ldap_users.py
@@ -2,17 +2,12 @@ from plone import api
 from plone.memoize.view import memoize
 from plone.memoize.view import memoize_contextless
 from Products.Five import BrowserView
+from Products.PluggableAuthService.interfaces.plugins import IUserEnumerationPlugin
 
 import logging
-import os
 
 
 logger = logging.getLogger(__name__)
-# When testing locally, you may not have LDAP configured.  You can switch to
-# searching for users in source_users by setting an environment variable.
-OIRA_SOURCE_USERS_INSTEAD_OF_LDAP = int(
-    os.getenv("OIRA_SOURCE_USERS_INSTEAD_OF_LDAP", 0)
-)
 
 
 class BaseManageLDAPUsersView(BrowserView):
@@ -60,13 +55,16 @@ class BaseManageLDAPUsersView(BrowserView):
     def enumerateUsersIds(self, query=""):
         if not query:
             return []
-        if OIRA_SOURCE_USERS_INSTEAD_OF_LDAP:
-            logger.warning("Querying source users instead of LDAP for %s", query)
-            au = api.portal.get_tool("acl_users")
-            results = au.source_users.enumerateUsers(query) or ()
-        else:
+        if self.ldap.is_plugin_active(IUserEnumerationPlugin):
             query = "*%s*" % query
             results = self.ldap.enumerateUsers(query) or ()
+        else:
+            logger.warning(
+                "LDAP plugin inactive for user enumeration. "
+                "Querying source_users instead."
+            )
+            au = api.portal.get_tool("acl_users")
+            results = au.source_users.enumerateUsers(query) or ()
         return sorted(result["id"] for result in results)
 
     def grant_roles(self, user):

--- a/src/osha/oira/content/browser/manage_ldap_users.py
+++ b/src/osha/oira/content/browser/manage_ldap_users.py
@@ -2,7 +2,6 @@ from plone import api
 from plone.memoize.view import memoize
 from plone.memoize.view import memoize_contextless
 from Products.Five import BrowserView
-from Products.PluggableAuthService.interfaces.plugins import IUserEnumerationPlugin
 
 import logging
 
@@ -55,16 +54,14 @@ class BaseManageLDAPUsersView(BrowserView):
     def enumerateUsersIds(self, query=""):
         if not query:
             return []
-        if self.ldap.is_plugin_active(IUserEnumerationPlugin):
-            query = "*%s*" % query
-            results = self.ldap.enumerateUsers(query) or ()
-        else:
-            logger.warning(
-                "LDAP plugin inactive for user enumeration. "
-                "Querying source_users instead."
-            )
-            au = api.portal.get_tool("acl_users")
-            results = au.source_users.enumerateUsers(query) or ()
+        # For a real LDAP plugin we need '*query*', but in development or on
+        # a test server you may have a fake LDAP plugin (same plugin as
+        # source_users), and then you need 'query'.
+        results = (
+            self.ldap.enumerateUsers(f"*{query}*")
+            or self.ldap.enumerateUsers(query)
+            or ()
+        )
         return sorted(result["id"] for result in results)
 
     def grant_roles(self, user):


### PR DESCRIPTION
This helps me when working on https://github.com/syslabcom/scrum/issues/4282 locally, as I don't have an active LDAP connection.  It will also help on https://test-admin-oira.osha.europa.eu/tool-creator, as that has no active LDAP either.

Initially I did this with an optional environment variable, see the first commit.

But then I realised I could check if the `pasldap` plugin was active for user enumeration.  See second commit.

Some options:

* Only use the first commit, if you prefer the explicitness of an environment variable.
* Prefer the `pasldap` check by squashing the commits.
* I guess we could also log a warning when `pasldap` is inactive, and in the warning suggest to set the environment variable.  Best of both worlds?

I prefer just squashing the current commits, but the other options are also okay for me.