### PR TITLE
Change the tiptap link edit panel to have a "Open web page in new window" option

### DIFF
--- a/news/4753.feature.rst
+++ b/news/4753.feature.rst
@@ -1,0 +1,2 @@
+Change the tiptap link edit panel to have a "Open web page in new window" option.
+@thet

--- a/src/osha/oira/ploneintranet/templates/quaive-form.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-form.pt
@@ -557,6 +557,15 @@
                          type="text"
                   />
                 </label>
+                <fieldset class="pat-checklist">
+                  <label>
+                    <tal:i18n i18n:translate="label_new_window">Open link in new window</tal:i18n>
+                    <input name="tiptap-target"
+                           type="checkbox"
+                           value="_blank"
+                    />
+                  </label>
+                </fieldset>
               </fieldset>
             </form>
             <div class="buttons button-bar pat-bumper">


### PR DESCRIPTION
This PR is a continuation of https://github.com/quaive/ploneintranet/pull/5874 as we also need to implement that in the quaive-form.pt in osha.oira.

It looks like this:

<img width="1402" height="496" alt="image" src="https://github.com/user-attachments/assets/6564fc00-518b-4267-b747-919996900e92" />


That's a best effort again
every other options did look broken.

The i18n msgid was reused from: https://github.com/euphorie/NuPlone/blob/72d50bd56c5e4b5b5bf598ab68645ef6f2820075/src/plonetheme/nuplone/locales/nuplone.pot#L469-L469

I based this PR on the main branch, but on alita we have a checkout of the `ale/3447/images-behavior` branch. I don't know what the correct one is.


Ref:
https://github.com/syslabcom/scrum/issues/4753
