### PR TITLE
Add Quaive variant of manage ldap users

### DIFF
--- a/news/4282.feature.rst
+++ b/news/4282.feature.rst
@@ -1,0 +1,1 @@
+Add quaive-manage-ldap-users.  [maurits]

--- a/src/osha/oira/ploneintranet/configure.zcml
+++ b/src/osha/oira/ploneintranet/configure.zcml
@@ -287,4 +287,22 @@
       layer="osha.oira.interfaces.IOSHAContentSkinLayer"
       />
 
+  <browser:page
+      name="quaive-manage-ldap-users"
+      for="euphorie.content.country.ICountry"
+      class="osha.oira.content.browser.manage_ldap_users.ManageCountryLDAPUsersView"
+      template="templates/quaive-manage-ldap-users.pt"
+      permission="euphorie.content.ManageCountry"
+      layer="osha.oira.interfaces.IOSHAContentSkinLayer"
+      />
+
+  <browser:page
+      name="quaive-manage-ldap-users"
+      for="euphorie.content.sector.ISector"
+      class="osha.oira.content.browser.manage_ldap_users.ManageSectorLDAPUsersView"
+      template="templates/quaive-manage-ldap-users.pt"
+      permission="euphorie.content.ManageCountry"
+      layer="osha.oira.interfaces.IOSHAContentSkinLayer"
+      />
+
 </configure>

--- a/src/osha/oira/ploneintranet/templates/quaive-manage-ldap-users.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-manage-ldap-users.pt
@@ -1,0 +1,121 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      xmlns:meta="http://xml.zope.org/namespaces/meta"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      metal:use-macro="context/@@layout/macros/layout"
+      i18n:domain="euphorie"
+>
+  <body>
+    <metal:title fill-slot="title">
+      Manage LDAP users in ${here/Title}
+    </metal:title>
+    <metal:content fill-slot="content">
+      <script type="text/javascript">
+    function check_role_change() {
+        var answer = confirm("Are you sure that you want to disable this Country Manager? This will remove ALL editing access!");
+        if (answer){
+            return true;
+        }
+        return false;
+    }
+      </script>
+
+
+      <h2>Existing users with local role
+        <em tal:condition="python:context.portal_type=='euphorie.country'">Country Manager</em><em tal:condition="python:context.portal_type=='euphorie.sector'">Sector Manager</em>
+        enabled</h2>
+      <tal:existing-roles define="
+                            userids view/local_roles_userids;
+                          ">
+
+        <p class="message notice"
+           tal:condition="python:context.portal_type=='euphorie.country' and not userids"
+        >There are no country managers for this country.</p>
+        <p class="message notice"
+           tal:condition="python:context.portal_type=='euphorie.sector' and not userids"
+        >There are no sector managers for this sector.</p>
+
+        <metal:macro define-macro="user-table">
+          <table tal:condition="nocall:userids">
+            <thead>
+              <tr>
+                <th>Login</th>
+                <th class="actions">&nbsp;</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tal:user repeat="userid userids">
+                <tr tal:define="
+                      user python:view.get_user(userid);
+                    "
+                    tal:condition="nocall:user"
+                >
+                  <td>${python:user.getProperty('login', None) or userid}</td>
+                  <td>
+                    <form action="${request/getURL}"
+                          method="post"
+                    >
+                      <input name="userid"
+                             type="hidden"
+                             value="${userid}"
+                      />
+                      <tal:button define="
+                                    has_managed_roles python:view.has_managed_roles(user);
+                                  ">
+
+                        <button class="micro floatAfter function"
+                                name="ldap_action"
+                                type="submit"
+                                value="grant"
+                                tal:condition="not:has_managed_roles"
+                        >Grant Roles</button>
+                        <button class="micro floatAfter function"
+                                id="revoke_role"
+                                name="ldap_action"
+                                onclick="${python:context.portal_type=='euphorie.country' and 'return check_role_change()' or None}"
+                                type="submit"
+                                value="revoke"
+                                tal:condition="has_managed_roles"
+                        >Revoke Roles</button>
+                      </tal:button>
+                      <tal:csrf replace="structure context/@@authenticator/authenticator" />
+                    </form>
+                  </td>
+                </tr>
+              </tal:user>
+            </tbody>
+          </table>
+        </metal:macro>
+      </tal:existing-roles>
+
+      <h2>Search for LDAP users</h2>
+      <form method="POST"
+            style="margin: 0 0 10px;"
+      >
+        <input name="SearchableText"
+               type="text"
+               value="${request/SearchableText|nothing}"
+        />
+        <button name="search-ldap"
+                type="submit"
+                value="1"
+        >Search</button>
+      </form>
+      <tal:ldap-users define="
+                        userids view/ldap_userids;
+                      ">
+        <tal:users condition="userids">
+          <metal:macro use-macro="template/macros/user-table">
+          </metal:macro>
+        </tal:users>
+      </tal:ldap-users>
+      <p tal:condition="python:context.portal_type=='euphorie.country'">This form allows you to grant the
+        <em>Country Manager</em>
+        role for "${context/title}" to selected users.</p>
+      <p tal:condition="python:context.portal_type=='euphorie.sector'">This form allows you to grant the
+        <em>Sector Manager</em>
+        role for "${context/title}" to selected users.</p>
+    </metal:content>
+  </body>
+</html>

--- a/src/osha/oira/ploneintranet/templates/quaive-manage-ldap-users.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-manage-ldap-users.pt
@@ -7,13 +7,19 @@
       i18n:domain="euphorie"
 >
   <body>
-    <metal:content fill-slot="content">
-      <h3>
-        Manage LDAP users in ${here/Title}
+    <metal:content fill-slot="content"
+                   tal:define="
+                     role python:'Country Manager' if context.portal_type=='euphorie.country' else 'Sector Manager';
+                   "
+    >
+      <h3 i18n:translate="manage_ldap_users_context">
+        Manage LDAP users in
+        <tal:title i18n:name="context">${here/Title}</tal:title>
       </h3>
 
-      <p>Existing users with local role
-        <em tal:condition="python:context.portal_type=='euphorie.country'">Country Manager</em><em tal:condition="python:context.portal_type=='euphorie.sector'">Sector Manager</em>
+      <p i18n:translate="existing_users_local_role">
+        Existing users with local role
+        <em i18n:name="role">${role}</em>
         enabled</p>
       <tal:existing-roles define="
                             userids view/local_roles_userids;
@@ -21,9 +27,11 @@
 
         <p class="message notice"
            tal:condition="python:context.portal_type=='euphorie.country' and not userids"
+           i18n:translate=""
         >There are no country managers for this country.</p>
         <p class="message notice"
            tal:condition="python:context.portal_type=='euphorie.sector' and not userids"
+           i18n:translate=""
         >There are no sector managers for this sector.</p>
 
         <metal:macro define-macro="user-table">
@@ -64,6 +72,7 @@
                               type="submit"
                               value="grant"
                               tal:condition="not:has_managed_roles"
+                              i18n:translate=""
                       >Grant Roles</button>
                       <button class="micro function pat-button icon-trash"
                               id="revoke_role"
@@ -72,6 +81,7 @@
                               type="submit"
                               value="revoke"
                               tal:condition="has_managed_roles"
+                              i18n:translate=""
                       >Revoke Roles</button>
                     </tal:button>
                     <tal:csrf replace="structure context/@@authenticator/authenticator" />
@@ -83,7 +93,9 @@
         </metal:macro>
       </tal:existing-roles>
 
-      <h3 style="margin-top: 0.5em">Search for LDAP users</h3>
+      <h3 style="margin-top: 0.5em"
+          i18n:translate=""
+      >Search for LDAP users</h3>
       <fieldset class="horizontal pat-form">
         <form class="pat-inject"
               method="POST"
@@ -106,6 +118,7 @@
                     style="width: 100%"
                     type="submit"
                     value="1"
+                    i18n:translate=""
             >Search</button>
           </span>
         </form>
@@ -118,12 +131,13 @@
           </metal:macro>
         </tal:users>
       </tal:ldap-users>
-      <p tal:condition="python:context.portal_type=='euphorie.country'">This form allows you to grant the
-        <em>Country Manager</em>
-        role for "${context/title}" to selected users.</p>
-      <p tal:condition="python:context.portal_type=='euphorie.sector'">This form allows you to grant the
-        <em>Sector Manager</em>
-        role for "${context/title}" to selected users.</p>
+      <p tal:condition="python:context.portal_type=='euphorie.country'"
+         i18n:translate="form_grants_manager_rights"
+      >This form allows you to grant the
+        <em i18n:name="role">${role}</em>
+        role for
+        <tal:title i18n:name="context">${context/title}</tal:title>
+        to selected users.</p>
     </metal:content>
   </body>
 </html>

--- a/src/osha/oira/ploneintranet/templates/quaive-manage-ldap-users.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-manage-ldap-users.pt
@@ -7,24 +7,14 @@
       i18n:domain="euphorie"
 >
   <body>
-    <metal:title fill-slot="title">
-      Manage LDAP users in ${here/Title}
-    </metal:title>
     <metal:content fill-slot="content">
-      <script type="text/javascript">
-    function check_role_change() {
-        var answer = confirm("Are you sure that you want to disable this Country Manager? This will remove ALL editing access!");
-        if (answer){
-            return true;
-        }
-        return false;
-    }
-      </script>
+      <h3>
+        Manage LDAP users in ${here/Title}
+      </h3>
 
-
-      <h2>Existing users with local role
+      <p>Existing users with local role
         <em tal:condition="python:context.portal_type=='euphorie.country'">Country Manager</em><em tal:condition="python:context.portal_type=='euphorie.sector'">Sector Manager</em>
-        enabled</h2>
+        enabled</p>
       <tal:existing-roles define="
                             userids view/local_roles_userids;
                           ">
@@ -37,71 +27,89 @@
         >There are no sector managers for this sector.</p>
 
         <metal:macro define-macro="user-table">
-          <table tal:condition="nocall:userids">
-            <thead>
-              <tr>
-                <th>Login</th>
-                <th class="actions">&nbsp;</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tal:user repeat="userid userids">
-                <tr tal:define="
-                      user python:view.get_user(userid);
-                    "
-                    tal:condition="nocall:user"
-                >
-                  <td>${python:user.getProperty('login', None) or userid}</td>
-                  <td>
-                    <form action="${request/getURL}"
-                          method="post"
-                    >
-                      <input name="userid"
-                             type="hidden"
-                             value="${userid}"
-                      />
-                      <tal:button define="
-                                    has_managed_roles python:view.has_managed_roles(user);
-                                  ">
+          <tal:users tal:condition="nocall:userids">
+            <tal:user repeat="userid userids">
+              <fieldset class="horizontal pat-form"
+                        tal:define="
+                          user python:view.get_user(userid);
+                        "
+                        tal:condition="nocall:user"
+              >
+                <span class="field-cluster layout-inline">
+                  <span class="output-field"
+                        style="display: inline-block; width: 66%; margin-top: 0.1em"
+                  >
+                      ${python:user.getProperty('login', None) or userid}
+                  </span>
+                  <form class="pat-inject float-after"
+                        action="${request/getURL}"
+                        method="post"
+                        style="width:33%"
+                        data-pat-inject="
+                            source: #mainContent::element;
+                            target: #mainContent::element;
+                          "
+                  >
+                    <input name="userid"
+                           type="hidden"
+                           value="${userid}"
+                    />
+                    <tal:button define="
+                                  has_managed_roles python:view.has_managed_roles(user);
+                                ">
 
-                        <button class="micro floatAfter function"
-                                name="ldap_action"
-                                type="submit"
-                                value="grant"
-                                tal:condition="not:has_managed_roles"
-                        >Grant Roles</button>
-                        <button class="micro floatAfter function"
-                                id="revoke_role"
-                                name="ldap_action"
-                                onclick="${python:context.portal_type=='euphorie.country' and 'return check_role_change()' or None}"
-                                type="submit"
-                                value="revoke"
-                                tal:condition="has_managed_roles"
-                        >Revoke Roles</button>
-                      </tal:button>
-                      <tal:csrf replace="structure context/@@authenticator/authenticator" />
-                    </form>
-                  </td>
-                </tr>
-              </tal:user>
-            </tbody>
-          </table>
+                      <button class="micro function pat-button default alert icon-ok-circle"
+                              name="ldap_action"
+                              style="width:100%; padding-bottom: 0.15em"
+                              type="submit"
+                              value="grant"
+                              tal:condition="not:has_managed_roles"
+                      >Grant Roles</button>
+                      <button class="micro function pat-button icon-trash"
+                              id="revoke_role"
+                              name="ldap_action"
+                              style="width:100%; padding-bottom: 0.15em"
+                              type="submit"
+                              value="revoke"
+                              tal:condition="has_managed_roles"
+                      >Revoke Roles</button>
+                    </tal:button>
+                    <tal:csrf replace="structure context/@@authenticator/authenticator" />
+                  </form>
+                </span>
+              </fieldset>
+            </tal:user>
+          </tal:users>
         </metal:macro>
       </tal:existing-roles>
 
-      <h2>Search for LDAP users</h2>
-      <form method="POST"
-            style="margin: 0 0 10px;"
-      >
-        <input name="SearchableText"
-               type="text"
-               value="${request/SearchableText|nothing}"
-        />
-        <button name="search-ldap"
-                type="submit"
-                value="1"
-        >Search</button>
-      </form>
+      <h3 style="margin-top: 0.5em">Search for LDAP users</h3>
+      <fieldset class="horizontal pat-form">
+        <form class="pat-inject"
+              method="POST"
+              style="margin: 0 0 10px;"
+              data-pat-inject="
+              source: #mainContent::element;
+              target: #mainContent::element;
+            "
+        >
+          <input class="pat-button output-field"
+                 name="SearchableText"
+                 style="display: inline-block; width: 66%; margin-top: 0em"
+                 type="text"
+                 value="${request/SearchableText|nothing}"
+          />
+          <span style="width:33%; float: right; padding-bottom: 0.15em">
+
+            <button class="micro function pat-button icon-search"
+                    name="search-ldap"
+                    style="width: 100%"
+                    type="submit"
+                    value="1"
+            >Search</button>
+          </span>
+        </form>
+      </fieldset>
       <tal:ldap-users define="
                         userids view/ldap_userids;
                       ">


### PR DESCRIPTION
This is for https://github.com/syslabcom/scrum/issues/4282

This replaces my PR #397.
In the new PR I don't touch the original `manage-ldap-users.pt`, but copy it to `quaive-`manage-ldap-users.pt` and restructure it there.

New screen shots:

<img width="725" height="515" alt="Screenshot 2026-05-28 at 14 48 21" src="https://github.com/user-attachments/assets/8971898d-de5a-4cb3-87a7-cd4a79d66e31" />

<img width="674" height="529" alt="Screenshot 2026-05-28 at 14 50 06" src="https://github.com/user-attachments/assets/bd61c34e-efe9-4f28-b450-9390f2977f02" />


