### PR TITLE
Quaive create preview: show info about already existing preview.

### DIFF
--- a/news/4608.feature.rst
+++ b/news/4608.feature.rst
@@ -1,0 +1,1 @@
+Quaive create preview: show info about already existing preview.  [maurits]

--- a/src/osha/oira/ploneintranet/quaive_publish.py
+++ b/src/osha/oira/ploneintranet/quaive_publish.py
@@ -1,5 +1,8 @@
+from Acquisition import aq_parent
+from euphorie.client.browser.publish import CopyToClient
 from euphorie.client.browser.publish import PreviewSurvey
 from euphorie.client.browser.publish import PublishSurvey
+from functools import cached_property
 from osha.oira.ploneintranet.quaive_mixin import QuaiveEditFormMixin
 
 
@@ -61,3 +64,39 @@ class PreviewSurveyQuaiveForm(QuaiveEditFormMixin, PreviewSurvey):
     The messages in the template are copied from
     'euphorie.client.browser.templates.preview.pt'.
     """
+
+    @cached_property
+    def existing_preview_version_id(self):
+        """Get the tool version id of the existing preview, if any.
+
+        Per tool (survey group) only ONE tool version (survey) can have a
+        preview.  The tool version id is stored in the version attribute
+        of the copy.
+        """
+        copy = CopyToClient(self.context, preview=True, readonly=True)
+        if copy is None:
+            return None
+        return copy.version
+
+    @cached_property
+    def current_preview_survey_info(self):
+        """Info on survey corresponding to current preview.
+
+        Should normally only be called when the current survey does not
+        correspond to the preview.  It should return info from one of our
+        siblings then.
+
+        I wanted to simply return the survey, but if something went wrong in
+        the past, I guess the preview might point to a survey that no longer
+        exists.
+        So return a dictionary
+        """
+        version_id = self.existing_preview_version_id
+        if not version_id:
+            return {"title": "", "url": ""}
+        parent = aq_parent(self.context)
+        survey = getattr(parent, version_id, None)
+        title = version_id if survey is None else survey.Title()
+        parent_path = "/".join(parent.getPhysicalPath()[3:])
+        url = f"OIRA_CREATOR_APP_URL/@@oira-edit/{parent_path}/{version_id}"
+        return {"title": title, "url": url}

--- a/src/osha/oira/ploneintranet/templates/quaive-preview.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-preview.pt
@@ -1,7 +1,37 @@
 <div id="quaive-content"
      i18n:domain="euphorie"
 >
-  <p i18n:translate="intro_preview">Are you sure you want to create a preview of this OiRA Tool? You
+  <p style="padding-bottom: 1em"
+     tal:condition="python:view.existing_preview_version_id"
+  >
+    <span i18n:translate="help_preview_existing">
+      There is already a preview of this OiRA Tool at
+      <strong i18n:name="url">${view/preview_url}</strong>.
+    </span>
+    <span tal:condition="python:view.existing_preview_version_id == context.id"
+          i18n:translate="help_preview_existing_ours"
+    >
+      You can update this if you want.
+    </span>
+    <span tal:condition="python:view.existing_preview_version_id != context.id"
+          i18n:translate="help_preview_existing_other"
+    >
+      The preview is for a different version:
+      <a href="${info/url}"
+         tal:define="
+           info python:view.current_preview_survey_info;
+         "
+         i18n:name="tool_title"
+      >
+        ${info/title}
+      </a>.
+      You can override this with the current version if you want.
+    </span>
+    <br />
+  </p>
+  <p style="padding-bottom: 1em"
+     i18n:translate="intro_preview"
+  >Are you sure you want to create a preview of this OiRA Tool? You
     can give the URL for the preview to others so they can test the OiRA Tool.
     To access the preview a standard OiRA client login is required.
   </p>

--- a/src/osha/oira/ploneintranet/templates/quaive-preview.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-preview.pt
@@ -6,7 +6,9 @@
   >
     <span i18n:translate="help_preview_existing">
       There is already a preview of this OiRA Tool at
-      <strong i18n:name="url">${view/preview_url}</strong>.
+      <a href="${view/preview_url}"
+         i18n:name="url"
+      ><strong>${view/preview_url}</strong></a>.
     </span>
     <span tal:condition="python:view.existing_preview_version_id == context.id"
           i18n:translate="help_preview_existing_ours"
@@ -37,7 +39,10 @@
   </p>
 
   <p i18n:translate="help_preview_url">The preview will be available at
-    <strong i18n:name="url">${view/preview_url}</strong>.</p>
+    <a href="${view/preview_url}"
+       i18n:name="url"
+    ><strong>${view/preview_url}</strong></a>.
+  </p>
 
   <span tal:replace="structure context/@@authenticator/authenticator"></span>
 </div>


### PR DESCRIPTION
This needs https://github.com/euphorie/Euphorie/pull/947

Refs https://github.com/syslabcom/scrum/issues/4608

Screen shots:

<img width="658" height="424" alt="Screenshot 2026-06-05 at 18 36 45" src="https://github.com/user-attachments/assets/50a79fef-404a-4d53-b068-9bc003401888" />

<img width="653" height="473" alt="Screenshot 2026-06-05 at 18 37 08" src="https://github.com/user-attachments/assets/862574d1-eb28-41fd-91d1-8a3670822ca2" />

The link in the last one points to the other survey within OiRA Creator.

Note that I added a bit more padding between the paragraphs.
