### PR TITLE
Quaive publish: make the link in the modal clickable.

### DIFF
--- a/news/4608.bugfix.rst
+++ b/news/4608.bugfix.rst
@@ -1,0 +1,1 @@
+Quaive publish: make the link in the modal clickable.  [maurits]

--- a/src/osha/oira/ploneintranet/templates/quaive-publish.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-publish.pt
@@ -24,6 +24,8 @@
   </tal:block>
   <tal:comment condition="nothing">We must generate the authenticator token on this side.</tal:comment>
   <p i18n:translate="help_publish_url">After publication the OiRA Tool will be available at
-    <strong i18n:name="url">${view/client_url}</strong>.</p>
+    <a href="${view/client_url}"
+       i18n:name="url"
+    ><strong>${view/client_url}</strong></a>.</p>
   <span tal:replace="structure context/@@authenticator/authenticator"></span>
 </div>


### PR DESCRIPTION
Previously I updated links in the preview dialog, but we have the same in the publish dialog.  That is fixed now.
See https://github.com/syslabcom/scrum/issues/4608#issuecomment-4677716791