### PR TITLE
Add Quaive version of sector management form

### DIFF
--- a/news/4889.feature.rst
+++ b/news/4889.feature.rst
@@ -1,0 +1,1 @@
+Add Quaive version of manage-users.  [maurits]

--- a/src/osha/oira/ploneintranet/configure.zcml
+++ b/src/osha/oira/ploneintranet/configure.zcml
@@ -288,6 +288,15 @@
       />
 
   <browser:page
+      name="quaive-manage-users"
+      for="euphorie.content.country.ICountry"
+      class="osha.oira.content.browser.country.OSHAManageUsers"
+      template="templates/quaive-manage-users.pt"
+      permission="euphorie.content.ManageCountry"
+      layer="osha.oira.interfaces.IOSHAContentSkinLayer"
+      />
+
+  <browser:page
       name="quaive-manage-ldap-users"
       for="euphorie.content.country.ICountry"
       class="osha.oira.content.browser.manage_ldap_users.ManageCountryLDAPUsersView"

--- a/src/osha/oira/ploneintranet/templates/quaive-manage-ldap-users.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-manage-ldap-users.pt
@@ -98,6 +98,7 @@
       >Search for LDAP users</h3>
       <fieldset class="horizontal pat-form">
         <form class="pat-inject"
+              action="${request/getURL}"
               method="POST"
               style="margin: 0 0 10px;"
               data-pat-inject="

--- a/src/osha/oira/ploneintranet/templates/quaive-manage-users.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-manage-users.pt
@@ -1,0 +1,98 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      xmlns:meta="http://xml.zope.org/namespaces/meta"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      meta:interpolation="true"
+      metal:use-macro="context/@@layout/macros/layout"
+      i18n:domain="euphorie"
+>
+  <body>
+    <metal:title fill-slot="title"
+                 i18n:translate="header_user_management"
+    >Manage users in
+      <tal:span i18n:name="country">${view/title}</tal:span></metal:title>
+    <div class="buttonBar"
+         metal:fill-slot="buttonbar"
+    >
+      <a class="button floatAfter"
+         href="${tools/context_url}/++add++euphorie.sector"
+         i18n:translate="button_add_sector"
+      >Add new sector</a>
+    </div>
+    <metal:content fill-slot="content"
+                   tal:define="
+                     managers view/managers;
+                   "
+    >
+      <style type="text/css">
+tr.even {
+  background-color: #f0f0f0;
+}
+tr.sector td {
+padding-top: 1em;
+padding-left: 0.5em;
+}
+tr.sector.simple td {
+  padding-bottom: 1em;
+}
+tr.managers td {
+padding-left: 2em;
+padding-bottom: 1em;
+}
+      </style>
+
+      <h2 i18n:translate="header_sectors">Sectors</h2>
+
+      <p class="message notice"
+         tal:condition="not:view/sectors"
+         i18n:translate="country_no_sectors"
+      >There are no sectors for this country.</p>
+
+      <table tal:condition="view/sectors">
+        <tbody>
+          <tal:sectors repeat="sector view/sectors">
+            <tr class="sector ${repeat/sector/even} ${python:'simple' if not sector.get('managers', None) else None}">
+              <td><a href="${sector/url}">${sector/title}</a></td>
+              <td><a class="micro button"
+                   href="${sector/url}/@@manage-ldap-users"
+                   i18n:translate="nav_ldapmanagement_sector"
+                >Manage sector access</a></td>
+              <td class="actions">
+                <form action="${sector/url}/@@lock"
+                      method="post"
+                >
+                  <tal:csrf replace="structure context/@@authenticator/authenticator" />
+                  <a class="micro floatAfter function button"
+                     href="${sector/url}/@@edit"
+                     i18n:translate="button_edit"
+                  >Edit</a>
+                </form>
+              </td>
+            </tr>
+            <tr class="managers ${repeat/sector/even}"
+                tal:condition="sector/managers"
+            >
+              <td colspan="3"><em>Managers</em>:
+              ${python:', '.join(sector['managers'])}
+              </td>
+            </tr>
+          </tal:sectors>
+        </tbody>
+      </table>
+
+      <h2 i18n:translate="header_country_managers">Country managers</h2>
+      <p class="message notice"
+         i18n:translate="notice_assign_country_manager"
+      >To view and assign country manager permissions, please use the
+        <a href="${context/absolute_url}/@@manage-ldap-users"
+           i18n:name="ldap_tab_link"
+           i18n:translate="nav_ldapmanagement_country"
+        >Manage country access</a>
+        tab.</p>
+
+    </metal:content>
+  </body>
+</html>

--- a/src/osha/oira/ploneintranet/templates/quaive-manage-users.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-manage-users.pt
@@ -26,20 +26,29 @@
       <table tal:condition="view/sectors">
         <tbody>
           <tal:sectors repeat="sector view/sectors">
-            <tr class="sector ${repeat/sector/even} ${python:'simple' if not sector.get('managers', None) else None}">
-              <td><a href="${sector/url}">${sector/title}</a></td>
-              <td><a class="micro button"
-                   href="${sector/url}/@@manage-ldap-users"
-                   i18n:translate="nav_ldapmanagement_sector"
-                >Manage sector access</a></td>
-            </tr>
-            <tr class="managers ${repeat/sector/even}"
-                tal:condition="sector/managers"
+            <fieldset class="horizontal pat-form"
+                      style="margin-bottom: 0.5em"
             >
-              <td colspan="2"><em>Managers</em>:
+              <p>
+                  ${sector/title}
+                <a class="pat-inject pat-tooltip icon-pencil close-panel"
+                   href="${sector/url}/@@quaive-manage-ldap-users"
+                   title="Manage sector access"
+                   data-pat-inject="
+                            source: #mainContent::element;
+                            target: #mainContent::element;
+                          "
+                   data-pat-tooltip="trigger: hover;  position-list: lm"
+                   i18n:attributes="title"
+                ></a>
+              </p>
+              <p style="margin-left: 0.5em"
+                 tal:condition="sector/managers"
+              >
+                <em i18n:translate="">Managers</em>:
               ${python:', '.join(sector['managers'])}
-              </td>
-            </tr>
+              </p>
+            </fieldset>
           </tal:sectors>
         </tbody>
       </table>
@@ -48,11 +57,16 @@
       <p class="message notice"
          i18n:translate="notice_assign_country_manager"
       >To view and assign country manager permissions, please use the
-        <a href="${context/absolute_url}/@@manage-ldap-users"
+        <a class="pat-inject"
+           href="${context/absolute_url}/@@quaive-manage-ldap-users"
+           data-pat-inject="
+                    source: #mainContent::element;
+                    target: #mainContent::element;
+                  "
            i18n:name="ldap_tab_link"
            i18n:translate="nav_ldapmanagement_country"
         >Manage country access</a>
-        tab.</p>
+        form.</p>
 
     </metal:content>
   </body>

--- a/src/osha/oira/ploneintranet/templates/quaive-manage-users.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-manage-users.pt
@@ -10,41 +10,13 @@
       i18n:domain="euphorie"
 >
   <body>
-    <metal:title fill-slot="title"
-                 i18n:translate="header_user_management"
-    >Manage users in
-      <tal:span i18n:name="country">${view/title}</tal:span></metal:title>
-    <div class="buttonBar"
-         metal:fill-slot="buttonbar"
-    >
-      <a class="button floatAfter"
-         href="${tools/context_url}/++add++euphorie.sector"
-         i18n:translate="button_add_sector"
-      >Add new sector</a>
-    </div>
     <metal:content fill-slot="content"
                    tal:define="
                      managers view/managers;
                    "
     >
-      <style type="text/css">
-tr.even {
-  background-color: #f0f0f0;
-}
-tr.sector td {
-padding-top: 1em;
-padding-left: 0.5em;
-}
-tr.sector.simple td {
-  padding-bottom: 1em;
-}
-tr.managers td {
-padding-left: 2em;
-padding-bottom: 1em;
-}
-      </style>
 
-      <h2 i18n:translate="header_sectors">Sectors</h2>
+      <h3 i18n:translate="header_sectors">Sectors</h3>
 
       <p class="message notice"
          tal:condition="not:view/sectors"
@@ -60,22 +32,11 @@ padding-bottom: 1em;
                    href="${sector/url}/@@manage-ldap-users"
                    i18n:translate="nav_ldapmanagement_sector"
                 >Manage sector access</a></td>
-              <td class="actions">
-                <form action="${sector/url}/@@lock"
-                      method="post"
-                >
-                  <tal:csrf replace="structure context/@@authenticator/authenticator" />
-                  <a class="micro floatAfter function button"
-                     href="${sector/url}/@@edit"
-                     i18n:translate="button_edit"
-                  >Edit</a>
-                </form>
-              </td>
             </tr>
             <tr class="managers ${repeat/sector/even}"
                 tal:condition="sector/managers"
             >
-              <td colspan="3"><em>Managers</em>:
+              <td colspan="2"><em>Managers</em>:
               ${python:', '.join(sector['managers'])}
               </td>
             </tr>
@@ -83,7 +44,7 @@ padding-bottom: 1em;
         </tbody>
       </table>
 
-      <h2 i18n:translate="header_country_managers">Country managers</h2>
+      <h3 i18n:translate="header_country_managers">Country managers</h3>
       <p class="message notice"
          i18n:translate="notice_assign_country_manager"
       >To view and assign country manager permissions, please use the


### PR DESCRIPTION
A.k.a. `manage-users` form.  So now `quaive-manage-users`.

Refs https://github.com/syslabcom/scrum/issues/4889

On the Quaive side, when using OiRA Creator and you are on a country, you get an extra link "Sector management" at the three dots:

<img width="392" height="362" alt="Screenshot 2026-06-17 at 22 05 58" src="https://github.com/user-attachments/assets/e083fa0c-2527-43ee-ad9b-f1321d574658" />

This shows a modal, with a tooltip when you hover over an edit link:

<img width="669" height="655" alt="Screenshot 2026-06-17 at 22 07 29" src="https://github.com/user-attachments/assets/178ba74d-7c03-42e9-9ca6-0a5df704cd3c" />

The edit link opens the sector management form in the same modal:

<img width="661" height="388" alt="Screenshot 2026-06-17 at 22 07 39" src="https://github.com/user-attachments/assets/dfe2d0a1-8ac9-43fa-9f6e-448bf6ea9409" />

That is the `quaive-manage-users.pt`.  Initially its search form no longer worked when opened via this route.  I had to explicitly add an action to this form.  The form around the Grant/Revoke buttons already had this.

Lastly, the "Manage country access" link also opens in the same modal.

Note: once you have followed one of the links, you can't go back to the original Sector management modal: you have to click to close the current modal, and then you can use the three dots menu again.  I think that is fine.

The first commit simply copies the original page template that is used in plain OiRA.  So look at the other commits to see the real changes.