### PR TITLE
Fix links in quaive-manage-users.

### DIFF
--- a/src/osha/oira/ploneintranet/templates/quaive-manage-users.pt
+++ b/src/osha/oira/ploneintranet/templates/quaive-manage-users.pt
@@ -32,7 +32,7 @@
               <p>
                   ${sector/title}
                 <a class="pat-inject pat-tooltip icon-pencil close-panel"
-                   href="${sector/url}/@@quaive-manage-ldap-users"
+                   href="OIRA_CREATOR_APP_URL/@@app-assessments-manage-access/${context/id}/${sector/id}"
                    title="Manage sector access"
                    data-pat-inject="
                             source: #mainContent::element;
@@ -58,7 +58,7 @@
          i18n:translate="notice_assign_country_manager"
       >To view and assign country manager permissions, please use the
         <a class="pat-inject"
-           href="${context/absolute_url}/@@quaive-manage-ldap-users"
+           href="OIRA_CREATOR_APP_URL/@@app-assessments-manage-access/${context/id}"
            data-pat-inject="
                     source: #mainContent::element;
                     target: #mainContent::element;


### PR DESCRIPTION
See https://github.com/syslabcom/scrum/issues/4889#issuecomment-4768863660

The previous links worked fine locally when using Quaive at http://localhost:8080/intranet and `quaive.osha.oira_admin_url` set to http://localhost:8080/tool-creator/sectors. But when I set this admin url to use 127.0.0.1 as domain, it no longer works, because of CORS problems.

This mimics what happens on https://test-admin-oira.osha.europa.eu/intranet/, where it seems all requests to https://test-admin-oira.osha.europa.eu/tool-creator/sectors get redirected to Quaive.

Apparently we should not make requests to the OiRA side directly, which I had kinda forgotten. In most other places this goes fine automatically because on the Quaive side we call a `transform_content` method, which gets all form tags, and sets `form.action = self.request.getURL()`, so the action matches the url in the browser on the Quaive side. In other cases on the OiRA side we make a url containing `OIRA_CREATOR_APP_URL`, which is what I do here now as well.