### PR TITLE
Oira Creator: let image scaling look the same as on client side

### DIFF
--- a/news/4755.bugfix.rst
+++ b/news/4755.bugfix.rst
@@ -1,0 +1,1 @@
+Oira Creator: let image scaling within a module look the same as on the client side.  [maurits]

--- a/src/osha/oira/client/browser/webhelpers.py
+++ b/src/osha/oira/client/browser/webhelpers.py
@@ -1,8 +1,8 @@
 from euphorie.client.browser.webhelpers import WebHelpers
 from logging import getLogger
 from osha.oira.client.model import UsersNotInterestedInCertificateStatusBox
+from osha.oira.utils import is_image_small
 from plone.memoize.instance import memoize
-from plone.namedfile.interfaces import INamedBlobImage
 from z3c.saconfig import Session
 
 log = getLogger(__name__)
@@ -28,11 +28,7 @@ class OSHAWebHelpers(WebHelpers):
 #toggle-osc { display: none !important;}</style>"""
 
     def is_image_small(self, context, fname="image", usecase="module"):
-        image = getattr(context, fname, None)
-        if image and INamedBlobImage.providedBy(image):
-            x, y = image.getImageSize()
-            if x < 1000 or y < 430:
-                return True
+        return is_image_small(context, fname=fname)
 
     def show_certificate_status_box(self):
         """Check if the current user should see his own certificate status

--- a/src/osha/oira/ploneintranet/configure.zcml
+++ b/src/osha/oira/ploneintranet/configure.zcml
@@ -42,7 +42,7 @@
   <browser:page
       name="quaive-view"
       for="euphorie.content.module.IModule"
-      class="euphorie.content.browser.module.ModuleView"
+      class=".quaive_view.QuaiveModuleView"
       template="templates/module_view.pt"
       permission="zope2.View"
       layer="osha.oira.interfaces.IOSHAContentSkinLayer"

--- a/src/osha/oira/ploneintranet/quaive_view.py
+++ b/src/osha/oira/ploneintranet/quaive_view.py
@@ -1,9 +1,11 @@
+from euphorie.content.browser.module import ModuleView
 from euphorie.content.browser.risk import RiskView
 from euphorie.content.solution import ISolution
 from euphorie.content.survey import get_tool_type
 from euphorie.content.utils import IToolTypesInfo
 from euphorie.content.utils import ToolTypesInfo
 from logging import getLogger
+from osha.oira.utils import is_image_small
 from plone import api
 from plone.memoize.view import memoize
 from plone.memoize.view import memoize_contextless
@@ -140,3 +142,9 @@ class QuaiveRiskView(RiskView):
             for solution in self.my_context.values()
             if ISolution.providedBy(solution)
         ]
+
+
+class QuaiveModuleView(ModuleView):
+
+    def is_image_small(self):
+        return is_image_small(self.context)

--- a/src/osha/oira/ploneintranet/templates/module_view.pt
+++ b/src/osha/oira/ploneintranet/templates/module_view.pt
@@ -8,21 +8,40 @@
       i18n:domain="euphorie"
 >
   <body>
-    <metal:slot fill-slot="quaive-body">
-      <div class="module-illustrations"
-           tal:define="
-             images context/@@images;
-             scale python:images.scale('image', height=510, width=510, direction='thumbnail');
-           "
-           tal:condition="scale"
+    <metal:slot fill-slot="quaive-body"
+                tal:define="
+                  is_image_small python:view.is_image_small();
+                "
+    >
+      <figure id="hero"
+              title="${context/caption|nothing}"
+              tal:define="
+                images context/@@images;
+                scale python:images.scale('image', width=590, height=1900, direction='thumbnail') if is_image_small else images.scale('image', scale='training', direction='thumbnail');
+              "
+              tal:condition="scale"
       >
-        <figure class="module-illustration">
-          <img alt=""
-               src="${scale/url}"
-          />
-          <figcaption></figcaption>
-        </figure>
-      </div>
+        <img alt=""
+             src="${scale/url}"
+             title="${context/caption|nothing}"
+             tal:condition="is_image_small"
+        />
+        <img alt=""
+             src="OIRA_CREATOR_APP_URL/++resource++quaive.osha/style/placeholder-21x9.png"
+             style="
+                background-size: cover;
+                background-position: center center;
+                width: 100%;
+                background-color: #e7f2fb;
+                background-image: url(${scale/url|nothing});
+              "
+             title="${context/caption|nothing}"
+             tal:condition="not:is_image_small"
+        />
+        <figcaption tal:condition="context/caption|nothing">
+              ${context/caption|nothing}
+        </figcaption>
+      </figure>
 
       <div class="pat-rich">
         <p tal:replace="structure python:context.Description()">Van belang is dat de spuitlans de

--- a/src/osha/oira/ploneintranet/templates/module_view.pt
+++ b/src/osha/oira/ploneintranet/templates/module_view.pt
@@ -27,7 +27,7 @@
              tal:condition="is_image_small"
         />
         <img alt=""
-             src="OIRA_CREATOR_APP_URL/++resource++quaive.osha/style/placeholder-21x9.png"
+             src="${portal_url}/++resource++euphorie.resources/assets/oira/style/placeholder-21x9.png"
              style="
                 background-size: cover;
                 background-position: center center;

--- a/src/osha/oira/utils.py
+++ b/src/osha/oira/utils.py
@@ -1,0 +1,9 @@
+from plone.namedfile.interfaces import INamedBlobImage
+
+
+def is_image_small(context, fname="image"):
+    image = getattr(context, fname, None)
+    if image and INamedBlobImage.providedBy(image):
+        x, y = image.getImageSize()
+        if x < 1000 or y < 430:
+            return True


### PR DESCRIPTION
This is for modules.

Refs https://github.com/syslabcom/scrum/issues/4755

Prototype defined its own nice way of showing images of a module. But this differed from how it was shown on the client: Prototype had rounded corners and a different scale.

Now I took over how it looks from `client/browser/templates/module_identification.pt` to `ploneintranet/templates/module_view.pt`.

On the OiRA client side, depending on the image size, a `${style_url}/placeholder-21x9.png` was used as the image, and the actual stored image was the background image.  Why not? `style_url` was defined in `webhelpers`, which is only defined on the client side. So I copied this placeholder image to `quaive.osha`.  That is done in https://github.com/quaive/quaive.osha/pull/207

Also, to determine whether an image was small (can be a portrait) the webhelpers had an `is_image_small` method.  I moved this to a new shared `utils.py`.